### PR TITLE
Add keywords to Paperboy desktop entry

### DIFF
--- a/data/io.github.thecalamityjoe87.Paperboy.desktop
+++ b/data/io.github.thecalamityjoe87.Paperboy.desktop
@@ -4,6 +4,7 @@ Exec=paperboy
 Icon=paperboy
 Type=Application
 Categories=Network;News;GTK;
+Keywords=news;rss;reader;feed;aggregator;
 StartupNotify=true
 StartupWMClass=io.github.thecalamityjoe87.Paperboy
 X-GNOME-FullName=Paperboy


### PR DESCRIPTION
The OpenDesktop (xdg) standard requires keywords in a .desktop file. This adds some suggested keywords. This also enables application launchers, including the GNOME Shell overview, to be able to search for this by keyword.