### PR TITLE
FIX: Regression introduced in prefsDialog

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('paperboy', 'vala',
-  version : '0.6.0a'
+  version : '0.6.2a'
 )
 
 gtk = dependency('gtk4')

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -63,6 +63,12 @@ chmod +x "$APPDIR/usr/bin/paperboy"
 if [ -x "$BUILD_DIR/rssFinder" ]; then
   cp "$BUILD_DIR/rssFinder" "$APPDIR/usr/bin/rssFinder"
   chmod +x "$APPDIR/usr/bin/rssFinder"
+  # Also copy into the namespaced data dir so runtime lookups find it
+  mkdir -p "$APPDIR/usr/share/org.gnome.Paperboy/tools"
+  cp "$BUILD_DIR/rssFinder" "$APPDIR/usr/share/org.gnome.Paperboy/tools/rssFinder"
+  # Provide a lowercase name as well for packagers that lowercase the binary
+  cp "$BUILD_DIR/rssFinder" "$APPDIR/usr/share/org.gnome.Paperboy/tools/rssfinder" 2>/dev/null || true
+  chmod +x "$APPDIR/usr/share/org.gnome.Paperboy/tools/rssFinder"
 else
   echo "Warning: rssFinder binary not found at $BUILD_DIR/rssFinder"
 fi


### PR DESCRIPTION
This pull request updates Paperboy to version 0.6.2a and significantly improves the user experience for location and feed discovery in the preferences dialog. The changes streamline the ZIP/city lookup workflow, enhance feedback to users, and modernize the UI by removing the "Use detected" button in favor of a more intuitive Save button flow. Additionally, feed discovery results are now presented in a dialog, and the packaging script ensures the `rssFinder` tool is available in all expected locations.

**Preferences dialog improvements:**

* The ZIP/city lookup workflow is streamlined: the "Use detected" button is removed, and the Save button is now enabled only after a successful search or if a location is already configured. The Save button now handles persisting the detected city, updating the UI, and triggering feed discovery.
* Feed discovery results from `rssFinder` are now shown in a dialog, listing discovered feeds and refreshing the main news window after dismissal if requested. This dialog runs on the main thread for proper UI updates.
* Improved feedback during ZIP lookups: spinner feedback is clarified, hint text is updated to inform the user when a city is detected, and Save button state is updated based on search results.

**Packaging and versioning:**

* Updates the application version to 0.6.2a in both `meson.build` and the About dialog.
* The AppImage packaging script now copies the `rssFinder` binary to both the main binary directory and the namespaced data directory, with support for lowercase naming to improve runtime compatibility.

**Debugging and reliability:**

* Adds detailed logging to the `spawn_rssfinder_async` workflow for easier debugging of process launches, exit codes, and dialog presentation. Also guards against null path returns when locating the binary.

These changes collectively modernize the preferences workflow, improve user feedback, and ensure the feed discovery tool is reliably available across environments.- Fix an issue where local feeds wouldn't update or show confirmation of new feeds when users set a (new) location.
- ui: remove the redundant "Use Detected" button.
- ui: Discovered feeds dialog for local news now shows which feeds were found from rssFinder.