### PR TITLE
packaging: update AppImage and include Debian build instructions

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,12 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+We are committed to creating a welcoming and respectful community.
+
+## Our Standards
+- Be respectful and considerate in all interactions.
+- Refrain from harassment or discriminatory language.
+- Assume good intentions and give constructive feedback.
+
+## Enforcement
+Project maintainers may remove content or ban contributors who violate these standards. If you experience or witness unacceptable behavior, please contact the maintainers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to This Project
+
+Thank you for your interest in contributing to Paperboy! To keep things smooth, please follow these guidelines:
+
+## How to Contribute
+- Fork the repository and create a new branch for your changes.
+- Ensure your code follows existing style and conventions.
+- Write tests for new features or bug fixes.
+- Submit a pull request with a clear description of your changes.
+
+## Issues
+- Check existing issues before creating a new one.
+- Provide detailed information and steps to reproduce any bug.
+- Use clear and descriptive titles.
+
+## Pull Requests
+- Keep PRs focused on a single change or feature.
+- Include relevant issue numbers (e.g., `Fixes #123`) when applicable.
+- Ensure all tests pass before submitting.

--- a/README.md
+++ b/README.md
@@ -14,12 +14,15 @@
 ## About
 A simple news app written in Vala, built with GTK4 and Libadwaita. My motivation for building this app because I wanted to have a simple, but beautiful native GTK4 news application similar to Apple News. Feel free to test, change, and contribute back to this project.
 
-Some cool features of Paperboy:
+## 🚀 Some cool features of Paperboy
 
-- **Ships with curated sources** like The Guardian, Reddit, BBC, and FOX News.
-- **Fetches articles through PaperboyAPI**, a custom API that aggregates news from multiple sources and categories.
-- **Lets you build a custom feed** by combining any sources and categories you want.
-- **Includes local news support**, so you can see what’s happening near you.
+- 📰 **Curated sources out of the box** – including The Guardian, Reddit, BBC, and FOX News.  
+- ⚡ **Powered by PaperboyAPI** – fetches articles from multiple sources and categories seamlessly.  
+- ⭐ **Follow news sources** – users can add sources they find through the API.  
+- 📡 **RSS feed support** – add any RSS feeds to Paperboy to follow additional websites or blogs.  
+- 🛠️ **Customizable feeds** – mix and match sources and categories to create your own personalized news stream.  
+- 📖 **In-app article viewing** – read articles without leaving the app.  
+- 🌍 **Local news support** – stay updated on what’s happening in your area.
 
 ### WARNING
 This app is very much so in an alpha state. It will definitely eat your dogs and throw your kittens outside. It's functional, but it's still very much so a WIP.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,0 +1,5 @@
+paperboy (0.6.3a-1) unstable; urgency=low
+
+  * Initial Debian packaging.
+
+ -- Isaac Joseph <calamityjoe87@gmail.com>  Tue, 01 Dec 2025 00:00:00 +0000

--- a/debian/control
+++ b/debian/control
@@ -1,0 +1,13 @@
+Source: paperboy
+Section: web
+Priority: optional
+Maintainer: Isaac Joseph <calamityjoe87@gmail.com>
+Build-Depends: debhelper-compat (= 13), meson, ninja-build, pkg-config, valac, libgtk-4-dev, libadwaita-1-dev, libgdk-pixbuf-2.0-dev, libjson-glib-dev, libgee-0.8-dev, libglib2.0-dev, libsqlite3-dev, libxml2-dev, libwebkitgtk-6.0-dev
+Standards-Version: 4.6.0
+
+Package: paperboy
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Description: RSS reader and article browser (Paperboy)
+ A small Vala/GTK4 application for reading RSS/Atom feeds and
+ viewing articles.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,11 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: Paperboy
+Source: https://github.com/thecalamityjoe87/paperboy
+
+Files: *
+Copyright: 2021-2025 The upstream authors
+License: GPL-3.0-or-later
+
+Files: packaging/debian/*
+Copyright: Isaac Joseph <calamityjoe87@gmail.com>
+License: GPL-3.0-or-later

--- a/debian/install
+++ b/debian/install
@@ -1,0 +1,1 @@
+tools/html2rss/target/release/html2rss usr/bin/

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+# Update GTK icon cache
+if [ -x /usr/bin/gtk-update-icon-cache ]; then
+    gtk-update-icon-cache -f /usr/share/icons/hicolor || true
+fi

--- a/debian/rules
+++ b/debian/rules
@@ -1,0 +1,3 @@
+#!/usr/bin/make -f
+%:
+	dh $@ --buildsystem=meson

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('paperboy', 'vala',
-  version : '0.6.2a'
+  version : '0.6.3a'
 )
 
 gtk = dependency('gtk4')
@@ -115,6 +115,9 @@ install_data('data/icons/128x128/paperboy.png', install_dir: join_paths(get_opti
 install_data('data/icons/256x256/paperboy.png', install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', '256x256', 'apps'))
 install_data('data/icons/512x512/paperboy.png', install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', '512x512', 'apps'))
 install_data('data/icons/paperboy.png', install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', '1024x1024', 'apps'))
+
+# Scalable SVG
+install_data('data/icons/scalable/paperboy.svg', install_dir: join_paths(get_option('datadir'), 'icons', 'hicolor', 'scalable', 'apps'))
 
 # Install app data (styles, icons) to a namespaced datadir for runtime lookup
 install_data('data/resources/style.css', install_dir: join_paths(get_option('datadir'), 'paperboy'))

--- a/packaging/appimage/AppDirTemplate/AppRun
+++ b/packaging/appimage/AppDirTemplate/AppRun
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
+set -euo pipefail
 HERE="$(dirname "$(readlink -f "${0}")")"
 # Ensure application can find its data files inside the AppDir
 export XDG_DATA_DIRS="$HERE/usr/share:${XDG_DATA_DIRS:-}"
-# Ensure bundled libraries are preferred
-export LD_LIBRARY_PATH="$HERE/usr/lib:${LD_LIBRARY_PATH:-}"
+# Prepend bundled fallback libs so libxml2.so.16 from the AppDir is preferred.
+# Keep $HERE/usr/lib in the search path for other bundled libs if present.
+# Use a safe expansion under `set -u` so referencing an unset LD_LIBRARY_PATH
+# doesn't trigger an unbound variable error inside the AppImage runtime.
+if [ -n "${LD_LIBRARY_PATH-}" ]; then
+  export LD_LIBRARY_PATH="$HERE/opt/fallback-libs:$LD_LIBRARY_PATH:$HERE/usr/lib"
+else
+  export LD_LIBRARY_PATH="$HERE/opt/fallback-libs:$HERE/usr/lib"
+fi
 exec "$HERE/usr/bin/paperboy" "$@"

--- a/src/ui/prefsDialog.vala
+++ b/src/ui/prefsDialog.vala
@@ -1527,7 +1527,7 @@ public class PrefsDialog : GLib.Object {
     var about = new Adw.AboutDialog();
     about.set_application_name("Paperboy");
     about.set_application_icon("paperboy"); // Use the correct icon name
-    about.set_version("0.6.2a");
+    about.set_version("0.6.3a");
     about.set_developer_name("thecalamityjoe87 (Isaac Joseph)");
     about.set_comments("A simple news app written in Vala, built with GTK4 and Libadwaita.");
     about.set_website("https://github.com/thecalamityjoe87/paperboy");
@@ -1536,6 +1536,7 @@ public class PrefsDialog : GLib.Object {
     about.present(parent);
     }
 
+    
     // Simple dialog to set a free-form user location string. This is a UI
     // shell that persists the value to NewsPreferences. Validation is minimal
     // (non-empty) and saving happens immediately when the user clicks Save.


### PR DESCRIPTION
This pull request introduces several improvements and new files focused on project documentation, packaging, and deployment for the Paperboy application. The main highlights are the addition of a code of conduct and contributing guidelines, enhanced feature documentation, initial Debian packaging, and improved AppImage build scripts for more robust distribution.

**Documentation Updates:**

* Added a `CODE_OF_CONDUCT.md` file to establish community standards and enforcement procedures.
* Added a `CONTRIBUTING.md` file detailing contribution, issue, and pull request guidelines for new contributors.
* Updated the feature list in `README.md` to reflect new capabilities such as RSS feed support and in-app article viewing, with improved formatting.

**Debian Packaging:**

* Introduced initial Debian packaging files (`debian/changelog`, `debian/control`, `debian/copyright`, `debian/install`, `debian/postinst`, `debian/rules`) to enable building and installing Paperboy as a Debian package.

**AppImage Build Improvements:**

* Enhanced `AppRun` and `build-appimage.sh` scripts to robustly handle library loading (especially `libxml2.so.16`), support fallback libraries, and reliably locate and rename AppImage artifacts for consistent builds.

**General Application Updates:**

* Updated application version to `0.6.3a` in both `meson.build` and the About dialog (`src/ui/prefsDialog.vala`).
* Added scalable SVG icon installation in `meson.build` for improved icon support.

These changes collectively improve the project's accessibility for contributors, package maintainers, and end users.- Added updated libxml2-16 libs for older distros
- Include debian build instructions