### PR TITLE
FIX: repair personalized feed toggle, address placeholder image issues, and correct AppImage Gsettings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('paperboy', 'vala',
-  version : '0.6.3a'
+  version : '0.6.4a'
 )
 
 gtk = dependency('gtk4')

--- a/packaging/appimage/AppDirTemplate/AppRun
+++ b/packaging/appimage/AppDirTemplate/AppRun
@@ -3,6 +3,8 @@ set -euo pipefail
 HERE="$(dirname "$(readlink -f "${0}")")"
 # Ensure application can find its data files inside the AppDir
 export XDG_DATA_DIRS="$HERE/usr/share:${XDG_DATA_DIRS:-}"
+# Point GSettings to the bundled schema directory so preferences can be saved/loaded
+export GSETTINGS_SCHEMA_DIR="$HERE/usr/share/glib-2.0/schemas:${GSETTINGS_SCHEMA_DIR:-}"
 # Prepend bundled fallback libs so libxml2.so.16 from the AppDir is preferred.
 # Keep $HERE/usr/lib in the search path for other bundled libs if present.
 # Use a safe expansion under `set -u` so referencing an unset LD_LIBRARY_PATH

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -196,6 +196,8 @@ set -euo pipefail
 HERE="$(dirname "$(readlink -f "${0}")")"
 # Ensure application can find its data files inside the AppDir
 export XDG_DATA_DIRS="$HERE/usr/share:${XDG_DATA_DIRS:-}"
+# Point GSettings to the bundled schema directory so preferences can be saved/loaded
+export GSETTINGS_SCHEMA_DIR="$HERE/usr/share/glib-2.0/schemas:${GSETTINGS_SCHEMA_DIR:-}"
 # Prepend bundled fallback libs so libxml2.so.16 from the AppDir is preferred.
 # Keep $HERE/usr/lib in the search path for other bundled libs if present.
 # Use a safe expansion under `set -u` so referencing an unset LD_LIBRARY_PATH

--- a/src/builders/placeholderBuilder.vala
+++ b/src/builders/placeholderBuilder.vala
@@ -139,6 +139,10 @@ public class PlaceholderBuilder : GLib.Object {
                     gradient.add_color_stop_rgb(0, 0.0, 0.2, 0.6);
                     gradient.add_color_stop_rgb(1, 0.1, 0.3, 0.8);
                     break;
+                case NewsSource.UNKNOWN:
+                    gradient.add_color_stop_rgb(0, 0.9, 0.9, 0.9);
+                    gradient.add_color_stop_rgb(1, 0.8, 0.8, 0.8);
+                    break;
                 default:
                     gradient.add_color_stop_rgb(0, 0.3, 0.3, 0.4);
                     gradient.add_color_stop_rgb(1, 0.5, 0.5, 0.6);
@@ -218,7 +222,7 @@ public class PlaceholderBuilder : GLib.Object {
             } catch (GLib.Error e) { }
         } catch (GLib.Error e) {
             // Fallback to text-based placeholder
-            string src = "News";
+            string src = "News Source";
             try { src = PlaceholderBuilder.get_source_name(source); } catch (GLib.Error ee) { }
             PlaceholderBuilder.create_source_text_placeholder(image, src, source, width, height);
         }
@@ -262,6 +266,10 @@ public class PlaceholderBuilder : GLib.Object {
                 case NewsSource.FOX:
                     gradient.add_color_stop_rgb(0, 0.0, 0.3, 0.7);
                     gradient.add_color_stop_rgb(1, 0.2, 0.5, 0.9);
+                    break;
+                case NewsSource.UNKNOWN:
+                    gradient.add_color_stop_rgb(0, 0.9, 0.9, 0.9);
+                    gradient.add_color_stop_rgb(1, 0.8, 0.8, 0.8);
                     break;
                 default:
                     gradient.add_color_stop_rgb(0, 0.4, 0.4, 0.4);
@@ -483,6 +491,7 @@ public class PlaceholderBuilder : GLib.Object {
             case NewsSource.REUTERS: return "Reuters";
             case NewsSource.NPR: return "NPR";
             case NewsSource.FOX: return "Fox News";
+            case NewsSource.UNKNOWN: return "News Source";
             default: return "News";
         }
     }
@@ -499,6 +508,7 @@ public class PlaceholderBuilder : GLib.Object {
             case NewsSource.NPR: icon_filename = "npr-logo.png"; break;
             case NewsSource.FOX: icon_filename = "foxnews-logo.png"; break;
             case NewsSource.WALL_STREET_JOURNAL: icon_filename = "wsj-logo.png"; break;
+            case NewsSource.UNKNOWN: return null;
             default: return null;
         }
         return DataPaths.find_data_file(GLib.Path.build_filename("icons", icon_filename));

--- a/src/managers/categoryManager.vala
+++ b/src/managers/categoryManager.vala
@@ -60,9 +60,16 @@ using Gee;
         return get_current_category() == "topten";
     }
 
-    // Check if we're viewing My Feed
-    public bool is_myfeed_view() {
+    // Check if the current category is "myfeed" (regardless of whether it's enabled)
+    // Use this to determine if we're LOOKING AT the My Feed page
+    public bool is_myfeed_category() {
         return get_current_category() == "myfeed";
+    }
+
+    // Check if we're viewing My Feed AND it's properly enabled
+    // Use this to determine if My Feed should SHOW CONTENT
+    public bool is_myfeed_view() {
+        return is_myfeed_category() && prefs.personalized_feed_enabled;
     }
 
     // Check if we're viewing Local News

--- a/src/managers/imageHandler.vala
+++ b/src/managers/imageHandler.vala
@@ -31,10 +31,16 @@ public class ImageHandler : GLib.Object {
         } catch (GLib.Error e) { prefer_local = false; }
 
         if (prefer_local) {
-            try { window.set_local_placeholder_image(pic, w, h); } catch (GLib.Error e) { try { window.set_placeholder_image_for_source(pic, w, h, window.infer_source_from_url(url)); } catch (GLib.Error _e) { } }
+            try { window.set_local_placeholder_image(pic, w, h); } catch (GLib.Error e) { try { PlaceholderBuilder.create_gradient_placeholder(pic, w, h); } catch (GLib.Error _e) { } }
             try { if (window.pending_local_placeholder != null) window.pending_local_placeholder.remove(pic); } catch (GLib.Error e) { }
         } else {
-            try { window.set_placeholder_image_for_source(pic, w, h, window.infer_source_from_url(url)); } catch (GLib.Error e) { try { window.set_local_placeholder_image(pic, w, h); } catch (GLib.Error _e) { } }
+            NewsSource source = window.infer_source_from_url(url);
+            // For unknown sources, use generic gradient placeholder instead of source branding
+            if (source == NewsSource.UNKNOWN) {
+                try { PlaceholderBuilder.create_gradient_placeholder(pic, w, h); } catch (GLib.Error e) { }
+            } else {
+                try { window.set_placeholder_image_for_source(pic, w, h, source); } catch (GLib.Error e) { try { PlaceholderBuilder.create_gradient_placeholder(pic, w, h); } catch (GLib.Error _e) { } }
+            }
         }
     }
 

--- a/src/services/newsSources.vala
+++ b/src/services/newsSources.vala
@@ -28,7 +28,8 @@ public enum NewsSource {
     BLOOMBERG,
     REUTERS,
     NPR,
-    FOX
+    FOX,
+    UNKNOWN
 }
 
 public delegate void SetLabelFunc(string text);

--- a/src/ui/contentView.vala
+++ b/src/ui/contentView.vala
@@ -192,11 +192,6 @@ public class ContentView : GLib.Object {
         toast_viewport_proxy.set_hexpand(false);
         toast_viewport_proxy.set_vexpand(false);
         toast_overlay.set_child(toast_viewport_proxy);
-        try { stderr.printf("DEBUG: ContentView: toast_overlay=%p visible=%s proxy=%p\n", toast_overlay, toast_overlay.get_visible() ? "YES" : "NO", toast_viewport_proxy); } catch (GLib.Error e) { }
-
-
-
-
 
         // Loading spinner container (initially hidden) - centered over main content
         loading_container = new Gtk.Box(Gtk.Orientation.VERTICAL, 16);
@@ -287,7 +282,7 @@ public class ContentView : GLib.Object {
         try { local_news_title.set_wrap(true); } catch (GLib.Error e) { }
         ln_inner.append(local_news_title);
 
-        local_news_hint = new Gtk.Label("Open the main menu (☰) and choose 'Set User Location' to configure your city or ZIP code.");
+        local_news_hint = new Gtk.Label("Open the main menu (☰) → choose 'Set User Location' to configure your city or ZIP code.");
         local_news_hint.add_css_class("dim-label");
         local_news_hint.set_halign(Gtk.Align.CENTER);
         local_news_hint.set_valign(Gtk.Align.CENTER);

--- a/src/ui/prefsDialog.vala
+++ b/src/ui/prefsDialog.vala
@@ -1527,7 +1527,7 @@ public class PrefsDialog : GLib.Object {
     var about = new Adw.AboutDialog();
     about.set_application_name("Paperboy");
     about.set_application_icon("paperboy"); // Use the correct icon name
-    about.set_version("0.6.3a");
+    about.set_version("0.6.4a");
     about.set_developer_name("thecalamityjoe87 (Isaac Joseph)");
     about.set_comments("A simple news app written in Vala, built with GTK4 and Libadwaita.");
     about.set_website("https://github.com/thecalamityjoe87/paperboy");

--- a/src/utils/sourceUtils.vala
+++ b/src/utils/sourceUtils.vala
@@ -40,6 +40,8 @@ public class SourceUtils {
                 return "NPR";
             case NewsSource.FOX:
                 return "Fox News";
+            case NewsSource.UNKNOWN:
+                return "News";
             default:
                 return "News";
         }
@@ -76,6 +78,8 @@ public class SourceUtils {
             case NewsSource.WALL_STREET_JOURNAL:
                 icon_filename = "wsj-logo.png";
                 break;
+            case NewsSource.UNKNOWN:
+                return null;
             default:
                 return null;
         }
@@ -87,8 +91,7 @@ public class SourceUtils {
 
     // Infer source from a URL by checking known domain substrings
     public static NewsSource infer_source_from_url(string? url) {
-        var prefs = NewsPreferences.get_instance();
-        if (url == null || url.length == 0) return prefs.news_source;
+        if (url == null || url.length == 0) return NewsSource.UNKNOWN;
         string low = url.down();
         if (low.index_of("guardian") >= 0 || low.index_of("theguardian") >= 0) return NewsSource.GUARDIAN;
         if (low.index_of("bbc.co") >= 0 || low.index_of("bbc.") >= 0) return NewsSource.BBC;
@@ -99,7 +102,7 @@ public class SourceUtils {
         if (low.index_of("reuters") >= 0) return NewsSource.REUTERS;
         if (low.index_of("npr.org") >= 0) return NewsSource.NPR;
         if (low.index_of("foxnews") >= 0 || low.index_of("fox.com") >= 0) return NewsSource.FOX;
-        // Unknown, return preference as a sensible default
-        return prefs.news_source;
+        // Unknown source - don't default to user preference to avoid incorrect branding
+        return NewsSource.UNKNOWN;
     }
 }


### PR DESCRIPTION
This pull request introduces support for an `UNKNOWN` news source throughout the application, improves placeholder image handling for articles with unknown sources, enhances user messaging for the personalized feed, and refines configuration management for user-preferred sources. Additionally, it updates packaging scripts to ensure proper GSettings schema loading in AppImage builds.

**Support for unknown news sources and improved placeholder handling:**

* Added `NewsSource.UNKNOWN` to the `NewsSource` enum and updated logic to use it when a news source cannot be determined from a URL. Placeholder images now use a generic gradient for unknown sources instead of branded visuals. (`src/services/newsSources.vala`, `src/ui/appWindow.vala`, `src/builders/placeholderBuilder.vala`, `src/managers/imageHandler.vala`)

**Personalized feed user experience improvements:**

* Refined the logic and messaging for the personalized feed overlay: clearer instructions when the feed is disabled or no categories are selected, and ensured the main content is hidden when showing overlay messages. Added a button to open the sources dialog directly from the overlay. (`src/managers/loadingStateManager.vala`, `src/ui/appWindow.vala`)

**Configuration management enhancements:**

* Changed the config file handling to only persist `preferred_sources` (no longer `viewed_articles`), and improved logic to preserve user data when saving configuration. (`src/services/prefs.vala`) 

**AppImage packaging improvements:**

* Updated AppImage startup scripts to set the `GSETTINGS_SCHEMA_DIR` environment variable, ensuring GSettings can save/load preferences in portable builds. (`packaging/appimage/AppDirTemplate/AppRun`, `packaging/appimage/build-appimage.sh`) 

**Other minor changes:**

* Bumped application version to `0.6.4a` in `meson.build`.
* Improved category manager logic to distinguish between viewing the My Feed category and whether it is enabled. (`src/managers/categoryManager.vala`)- Add UNKNOWN enum value to NewsSource for unrecognized article sources
- Update source inference to return UNKNOWN instead of defaulting to user preference

**BUG FIXES:**

- Use generic gradient placeholders for UNKNOWN sources instead of branded logos
- Fix personalized feed toggle to properly control My Feed content fetching
- Add is_myfeed_category() to distinguish between viewing category vs enabled state
- Show instructions overlay when personalized feed is disabled
- Hide "No more articles" message when instruction overlays are visible
- Clean up config.ini to only store preferred_sources (remove viewed_articles and other unused keys)
- Add GSETTINGS_SCHEMA_DIR to AppImage for GSettings persistence
- Wire "Select news sources" button to open preferences dialog