### PR TITLE
V0.8.1a

### DIFF
--- a/data/resources/io.github.thecalamityjoe87.Paperboy.gschema.xml
+++ b/data/resources/io.github.thecalamityjoe87.Paperboy.gschema.xml
@@ -109,6 +109,17 @@
       <description>List of category IDs included in the personalized feed</description>
     </key>
 
+    <!-- Separate from personalized-categories on purpose: a custom RSS
+         feed's own "enabled" switch (see Preferences -> Feeds) controls
+         whether it exists/shows in the sidebar at all, independent of
+         whether its articles are merged into My Feed. This list is that
+         second, independent opt-in - which feeds actually show in My Feed. -->
+    <key name="myfeed-included-feeds" type="as">
+      <default>[]</default>
+      <summary>My Feed custom feed opt-ins</summary>
+      <description>URLs of custom RSS feeds included in My Feed, independent of whether the feed is otherwise enabled</description>
+    </key>
+
     <!-- Empty means every league SportsScoresService knows about is shown;
          a league key here is hidden from the Sports score-card sections.
          Opt-out (rather than opt-in, like personalized-categories) so a

--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -488,6 +488,18 @@
     min-height: 0;
 }
 
+/* "..." button under a row's end, jumping to that row's full page. */
+.section-more-button {
+    color: alpha(@window_fg_color, 0.65);
+    font-size: 14px;
+    font-weight: bold;
+    padding: 4px 12px;
+}
+
+.section-more-button:hover {
+    color: @window_fg_color;
+}
+
 
 .navigation-sidebar .sidebar-item-row {
     background-color: transparent;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+paperboy (0.8.1a-1) unstable; urgency=low
+
+  * My Feed redesigned as interleaved source/category rows, with custom
+    RSS feeds able to opt in independently via a new Personalization
+    subpage.
+  * Fixed a memory/freeze regression from the My Feed redesign by capping
+    live card widgets per row and tightening HTTP concurrency.
+  * Fixed built-in sources disappearing from My Feed under load, and
+    circular logos being stretched instead of center-cropped.
+  * Fixed Sports' hero carousel staying empty on first load, and My
+    Feed's sidebar unread badge showing inflated counts.
+  * Added a "Go to category" button on Front Page/My Feed rows for quick
+    navigation to the full category page.
+  * Added a flatpak build file.
+
+ -- Isaac Joseph <calamityjoe87@gmail.com>  Mon, 07 Sep 2026 00:00:00 +0000
+
 paperboy (0.8.0a-1) unstable; urgency=low
 
   * Release 0.8.0a.

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('paperboy', 'vala',
-  version : '0.8.0a',
+  version : '0.8.1a',
   meson_version : '>=0.59.0'
 )
 

--- a/packaging/appimage/build-appimage.sh
+++ b/packaging/appimage/build-appimage.sh
@@ -227,6 +227,13 @@ if [ -d "$ICON_SRC_DIR" ]; then
     mkdir -p "$APPDIR/usr/share/icons/hicolor/scalable/apps"
     cp "$ICON_SRC_DIR/scalable/paperboy.svg" "$APPDIR/usr/share/icons/hicolor/scalable/apps/paperboy.svg" 2>/dev/null || true
   fi
+  # Copy the app-id-prefixed symbolic action icons (open-menu, sidebar-show,
+  # view-refresh) so the header bar uses our vendored glyphs instead of
+  # falling back to the system icon theme's own versions of those names.
+  if [ -d "$ICON_SRC_DIR/hicolor/scalable/actions" ]; then
+    mkdir -p "$APPDIR/usr/share/icons/hicolor/scalable/actions"
+    cp "$ICON_SRC_DIR/hicolor/scalable/actions/"*.svg "$APPDIR/usr/share/icons/hicolor/scalable/actions/" 2>/dev/null || true
+  fi
 else
   echo "Warning: icons not found in $ICON_SRC_DIR"
 fi

--- a/packaging/flatpak/io.github.thecalamityjoe87.Paperboy.yaml
+++ b/packaging/flatpak/io.github.thecalamityjoe87.Paperboy.yaml
@@ -1,0 +1,66 @@
+app-id: io.github.thecalamityjoe87.Paperboy
+runtime: org.gnome.Platform
+runtime-version: '49'
+sdk: org.gnome.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
+command: paperboy
+
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  # GeoClue is a system D-Bus service (not portal-mediated for this API), needed
+  # for the Local News location lookup.
+  - --system-talk-name=org.freedesktop.GeoClue2
+
+modules:
+  # geocode-glib-2.0 isn't part of the org.gnome.Platform//49 runtime, so it's
+  # built from source here. libgeoclue, libsoup-3.0, json-glib, gee, sqlite,
+  # libxml2 and webkitgtk-6.0 are all already provided by the runtime.
+  - name: geocode-glib
+    buildsystem: meson
+    config-opts:
+      - -Dsoup2=false
+      - -Denable-introspection=false
+      - -Denable-gtk-doc=false
+      - -Denable-installed-tests=false
+    sources:
+      - type: archive
+        url: https://download.gnome.org/sources/geocode-glib/3.26/geocode-glib-3.26.4.tar.xz
+        sha256: 2d9a6826d158470449a173871221596da0f83ebdcff98b90c7049089056a37aa
+
+  - name: paperboy
+    buildsystem: meson
+    build-options:
+      # Needed because meson.build shells out to `cargo build --release` for
+      # tools/html2rss during configure. This is fine for a local install but
+      # is not something Flathub would accept (it forbids network access
+      # during build) - a real submission would need vendored cargo sources.
+      append-path: /usr/lib/sdk/rust-stable/bin
+      build-args:
+        - --share=network
+    sources:
+      - type: dir
+        path: ../..
+        skip:
+          - build
+          - AppDir
+          - .git
+          - '*.AppImage'
+    # meson.build installs the app icons as plain "paperboy.{png,svg}", which
+    # is fine for a native/AppImage install (icon theme lookup is by name,
+    # not app id) but flatpak's icon exporter only allows exporting icons
+    # whose filename matches the app id - anything else is silently dropped,
+    # so the app would show up with no icon in a launcher. Copy them to
+    # app-id-named files and repoint the desktop file's Icon= at the copy.
+    post-install:
+      - |
+        for size in 128x128 256x256 512x512; do
+          install -Dm644 "${FLATPAK_DEST}/share/icons/hicolor/${size}/apps/paperboy.png" \
+            "${FLATPAK_DEST}/share/icons/hicolor/${size}/apps/${FLATPAK_ID}.png"
+        done
+      - install -Dm644 "${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/paperboy.svg" "${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg"
+      - sed -i "s/^Icon=paperboy$/Icon=${FLATPAK_ID}/" "${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop"

--- a/src/main.vala
+++ b/src/main.vala
@@ -73,11 +73,12 @@ private const int M_ARENA_MAX = -8;
 private const int M_ARENA_TEST = -7;
 
 public static int main(string[] args) {
-    // Caps glibc's per-thread malloc arenas: the image download/decode
-    // worker pools' allocate/free churn was fragmenting memory across many
-    // arenas that never got returned to the OS, ballooning RSS past 2GB
-    // independent of actual live data (confirmed via heaptrack).
-    mallopt(M_ARENA_MAX, 2);
+    // Caps glibc's malloc arenas: uncapped, concurrent image/XML worker
+    // churn fragments memory across arenas and balloons RSS. 4 is enough
+    // for HttpClientUtils.MAX_CONCURRENT_REQUESTS worker threads to avoid
+    // serializing on too few arena locks, while staying well under
+    // glibc's default (which scales with core count).
+    mallopt(M_ARENA_MAX, 4);
     mallopt(M_ARENA_TEST, 1);
 
     var app = new PaperboyApp();

--- a/src/managers/articleManager.vala
+++ b/src/managers/articleManager.vala
@@ -30,10 +30,9 @@ namespace Managers {
         public const int MAX_CAROUSEL_SLIDES = 5;
         
         // Layout dimensions
-        // Hero cards now lay text/picture side by side instead of stacked, so
-        // the picture spans the card's full height - default/max are kept
-        // equal to size fetched images and placeholders at the actual
-        // rendered height instead of the old (shorter) stacked-image height.
+        // Hero cards lay text/picture side by side, so the picture spans the
+        // card's full height - default/max must match so images and
+        // placeholders size consistently.
         public const int HERO_MAX_HEIGHT = 460;
         public const int HERO_DEFAULT_HEIGHT = 460;
         public const int TOPTEN_HERO_MAX_HEIGHT = 480;
@@ -46,18 +45,34 @@ namespace Managers {
         
         public Gee.ArrayList<ArticleItem> article_buffer;
         public Gee.ArrayList<ArticleItem> remaining_articles;
-        // PERFORMANCE: per-category count of remaining_articles, kept in
-        // sync on every add/remove so remaining_count_for_category() is O(1)
-        // instead of rescanning the whole (potentially large) overflow queue.
+        // Per-category counts of remaining_articles, kept in sync on every
+        // add/remove so remaining_count_for_category() is O(1).
         private Gee.HashMap<string, int> remaining_category_counts;
-        // Debounce latch for reveal_sections_with_pending_overflow(): a whole
-        // batch of queued overflow articles (e.g. ~95 frontpage cards in one
-        // Idle.add callback) should only trigger one reveal pass, not one per
-        // article.
+        // Debounces reveal_sections_with_pending_overflow() so a whole batch
+        // of queued overflow articles triggers one reveal pass, not one per article.
         private bool reveal_pending = false;
         public int articles_shown = 0;
-        
-        // Track URLs seen in current view to prevent duplicate cards (race condition fix)
+
+        // Per-row real-card counts for My Feed (keyed by section key, e.g.
+        // "source:guardian" or a bare category id), reset each fetch. My Feed
+        // has many independent rows rather than one flat grid, so each row
+        // gets its own modest cap instead of sharing articles_shown/INITIAL_ARTICLE_LIMIT
+        // (see add_item) - otherwise a full load could build hundreds of
+        // real card widgets, each with its own image fetch, at once.
+        private Gee.HashMap<string, int>? myfeed_row_card_counts = null;
+        private const int MYFEED_ROW_CARD_CAP = 10;
+
+        // URLs that actually got a real card built in the current My Feed
+        // build (see place_myfeed_article_cards) - reset once per My Feed
+        // fetch by LayoutManager.prepare_myfeed_sections(), not by the
+        // general clear_articles() (which runs on every category switch and
+        // would otherwise wipe this the moment the user leaves My Feed).
+        // ArticleStateStore.get_unread_count_for_myfeed() uses this instead
+        // of the full registered-article pool, which includes far more
+        // articles than MYFEED_ROW_CARD_CAP ever lets onto the page.
+        private Gee.HashSet<string>? myfeed_displayed_urls = null;
+
+        // Track URLs seen in current view to prevent duplicate cards
         private Gee.HashSet<string> seen_urls;
         
         // Category distribution
@@ -93,10 +108,6 @@ namespace Managers {
             seen_urls = new Gee.HashSet<string>();
         }
 
-        /**
-         * Open article in app with offline check
-         * Centralized method to handle opening articles in the article sheet
-         */
         public void open_article_in_app_if_online(string article_url) {
             var network_monitor = GLib.NetworkMonitor.get_default();
             if (!network_monitor.get_network_available()) {
@@ -109,10 +120,6 @@ namespace Managers {
             if (window.article_sheet != null) window.article_sheet.open(normalized);
         }
 
-        /**
-         * Open article in browser with offline check
-         * Centralized method to handle opening articles in external browser
-         */
         public void open_article_in_browser_if_online(string article_url) {
             var network_monitor = GLib.NetworkMonitor.get_default();
             if (!network_monitor.get_network_available()) {
@@ -125,34 +132,21 @@ namespace Managers {
             if (window.article_pane != null) window.article_pane.open_article_in_browser(normalized);
         }
 
-        /**
-         * Check if a category has article limits applied (most categories do)
-         */
         private bool is_limited_category(string category) {
             return CategoryManager.is_limited_category(category);
         }
 
-        /**
-         * Check if this is a regular news category (not frontpage, topten, myfeed, local_news, saved, or RSS)
-         */
         private bool is_regular_news_category(string category) {
             return CategoryManager.is_regular_news_category(category);
         }
-        
-        /**
-         * Normalize source name for consistent tracking
-         */
+
         private string? normalize_source_name(string? source_name, string category_id, string url) {
             return SourceManager.normalize_source_name(source_name, category_id, url);
         }
-        
-        /**
-         * Queue an article for the "Load More" overflow
-         * Returns true if article was queued, false if it was a duplicate
-         */
+
+        // Returns false if the article is a duplicate (already queued this view).
         private bool queue_overflow_article(string title, string url, string? thumbnail_url,
                                             string category_id, string? source_name, string? published = null, string? snippet = null) {
-            // Normalize and check for duplicates
             string normalized_url = "";
             normalized_url = window.normalize_article_url(url); 
             
@@ -179,15 +173,11 @@ namespace Managers {
                 window.article_state_store.register_article(norm, category_id, normalized_source);
             }
 
-            // A category that got zero cards into the initial 25-article
-            // cap would otherwise stay permanently hidden with no way to
-            // reach its queued overflow - see
-            // LayoutManager.reveal_sections_with_pending_overflow().
-            //
-            // PERFORMANCE: debounced via a single Idle.add latch so a whole
-            // batch of queued articles (all added synchronously from one
-            // fetcher callback) triggers exactly one reveal pass instead of
-            // one per article.
+            // A category with zero cards in the initial cap would otherwise
+            // stay hidden with no way to reach its queued overflow - see
+            // LayoutManager.reveal_sections_with_pending_overflow(). Debounced
+            // via a single Idle.add latch so a batch of articles triggers one
+            // reveal pass, not one per article.
             if (window.layout_manager != null && !reveal_pending) {
                 reveal_pending = true;
                 GLib.Idle.add(() => {
@@ -202,12 +192,8 @@ namespace Managers {
             return true;
         }
 
-        /**
-         * The real category for a queued overflow article. On Front Page,
-         * category_id is always the literal string "frontpage" - the actual
-         * category travels in source_name as a "##category::<cat>" suffix
-         * (same convention used when building each card's category chip).
-         */
+        // On Front Page, category_id is always "frontpage" - the real
+        // category travels in source_name as a "##category::<cat>" suffix.
         private string extract_display_category(ArticleItem item) {
             string cat = item.category_id;
             if (cat == "frontpage" && item.source_name != null) {
@@ -219,31 +205,19 @@ namespace Managers {
             return cat;
         }
 
-        /**
-         * How many overflow articles for one category are still queued -
-         * used by the category-section nav button to decide whether to show
-         * a "load more" affordance once that row is scrolled to its end.
-         */
         public int remaining_count_for_category(string cat) {
             if (remaining_category_counts == null) return 0;
             return remaining_category_counts.get(cat);
         }
 
-        /**
-         * Load the next batch of queued overflow articles for one category
-         * only, appending them to that category's section (existing card
-         * placement already routes by category via the same
-         * "##category::" parsing, so no extra wiring is needed there).
-         * Removes matched items from the shared remaining_articles pool -
-         * see load_more_articles() for why removal (not an index cursor) is
-         * required now that two flows draw from the same queue.
-         */
+        // Removes matched items from the shared remaining_articles pool
+        // rather than tracking an index cursor, since load_more_articles()
+        // also draws from the same queue.
         public void load_more_for_category(string cat, int max_to_load = LOAD_MORE_BATCH_SIZE) {
             if (remaining_articles == null) return;
 
-            // Snapshot the section's current card count so newly appended
-            // cards can be told apart afterward and given the same
-            // fade/slide entrance as the global "Load more articles" flow.
+            // Snapshot current card count so newly appended cards can be
+            // given the same fade/slide entrance as the global "load more" flow.
             Gtk.Widget? row = (window != null && window.layout_manager != null)
                 ? window.layout_manager.get_category_section_row(cat)
                 : null;
@@ -288,19 +262,37 @@ namespace Managers {
             }
         }
 
-        /**
-         * Check if debug mode is enabled
-         */
         private bool debug_enabled() {
             string? e = Environment.get_variable("PAPERBOY_DEBUG");
             return e != null && e.length > 0;
         }
 
+        // My Feed's row identity for one article ("source:<id>" or
+        // "customfeed:<url>"). Must be resolved before normalize_source_name
+        // rewrites source_name into a display name, since matching against
+        // enabled sources depends on seeing the raw name/URL.
+        private string? resolve_myfeed_row_key_hint(string category_id, string? source_name) {
+            if (category_id == "myfeed") {
+                return (source_name != null && source_name.length > 0) ? "customfeed:" + source_name : null;
+            }
+            if (source_name == null || source_name.length == 0 || window.source_manager == null) return null;
+            foreach (var src in window.source_manager.get_enabled_source_enums()) {
+                if (SourceManager.source_name_matches(src, source_name)) {
+                    return "source:" + SourceManager.source_enum_to_id(src);
+                }
+            }
+            return null;
+        }
+
         public void add_item(string title, string url, string? thumbnail_url, string category_id, string? source_name, string? published = null, string? snippet = null) {
-            // Check if we're viewing a category with article limits
-            if (is_limited_category(window.prefs.category)) {
+            bool is_myfeed = window.category_manager.is_myfeed_view();
+
+            // My Feed doesn't use the flat article-count cap: its rows are
+            // independent scrolling strips, not one shared grid, and several
+            // row kinds have no "load more" path to rescue overflow (see
+            // LayoutManager.reveal_sections_with_pending_overflow).
+            if (!is_myfeed && is_limited_category(window.prefs.category)) {
                 lock (articles_shown) {
-                    // If we've reached the limit, queue remaining articles for "Load More"
                     if (articles_shown >= INITIAL_ARTICLE_LIMIT) {
                         if (queue_overflow_article(title, url, thumbnail_url, category_id, source_name, published, snippet)) {
                             show_load_more_button();
@@ -310,32 +302,31 @@ namespace Managers {
                 }
             }
 
-            // Normalize source name for consistent tracking
+            string? myfeed_row_key_hint = is_myfeed ? resolve_myfeed_row_key_hint(category_id, source_name) : null;
+
             string? final_source_name = normalize_source_name(source_name, category_id, url);
-            
-            // Normalize URL for deduplication
+
             string normalized = "";
             if (url != null) normalized = window.normalize_article_url(url);
             if (normalized == null) normalized = "";
 
-            // Early dedup check: Skip if we've already seen this URL in this view session.
-            // This prevents race conditions where multiple async fetches add the same article
-            // before the first one registers its picture in url_to_picture.
-            // Note: Top Ten allows duplicates intentionally to show headlines from multiple providers.
+            // Skip if already seen this view session, to avoid duplicate cards
+            // when multiple async fetches race on the same URL. Top Ten allows
+            // duplicates intentionally (same headline from multiple providers).
             if (window.prefs.category != "topten" && normalized.length > 0 && seen_urls != null) {
                 lock (seen_urls) {
                     if (seen_urls.contains(normalized)) {
-                        // Already added this article - but if this duplicate call
-                        // carries a published date the card doesn't have yet (e.g.
-                        // it was first shown from an on-disk cache entry that
-                        // predates this field, and a fresh fetch just resolved
-                        // one), backfill the already-rendered card's time label in
-                        // place instead of silently dropping the newer data.
+                        // Backfill the already-rendered card's time label if this
+                        // duplicate call carries a published date it doesn't have yet.
                         if (published != null && published.length > 0 && window.view_state != null) {
-                            Gtk.Widget? existing_widget = window.view_state.url_to_card.get(normalized);
-                            Gtk.Label? existing_time_label = existing_widget != null ? existing_widget.get_data<Gtk.Label>("article-time-label") : null;
-                            if (existing_time_label != null && existing_time_label.get_text() == "") {
-                                existing_time_label.set_text(DateUtils.time_ago(published));
+                            var existing_widgets = window.view_state.get_cards_for_url(normalized);
+                            if (existing_widgets != null) {
+                                foreach (var existing_widget in existing_widgets) {
+                                    Gtk.Label? existing_time_label = existing_widget.get_data<Gtk.Label>("article-time-label");
+                                    if (existing_time_label != null && existing_time_label.get_text() == "") {
+                                        existing_time_label.set_text(DateUtils.time_ago(published));
+                                    }
+                                }
                             }
                         }
                         return;
@@ -360,14 +351,10 @@ namespace Managers {
                 }
             }
             if (existing != null && thumbnail_url != null && thumbnail_url.length > 0) {
-                    // Normally reuse an existing Picture mapping to avoid duplicate
-                    // image widgets for the same normalized URL. However, the
-                    // Top Ten view intentionally displays many headlines from
-                    // multiple providers and we should not dedupe by the
-                    // normalized image key there — doing so can collapse
-                    // distinct headlines that happen to normalize to the same
-                    // URL (tracking/query params removed). Allow Top Ten to
-                    // create separate cards even when an image mapping exists.
+                    // Reuse an existing Picture mapping to avoid duplicate image
+                    // widgets for the same normalized URL. Skip on Top Ten, where
+                    // distinct headlines can normalize to the same URL (tracking
+                    // params stripped) and shouldn't collapse into one card.
                     if (window.prefs.category != "topten") {
                         var info = window.image_manager.hero_requests.get(existing);
                         int target_w = 400;
@@ -380,20 +367,17 @@ namespace Managers {
                         }
                         int target_h = info != null ? info.last_requested_h : (int)(target_w * 0.5);
                         if (window.image_manager != null) window.image_manager.pending_local_placeholder.set(existing, category_id == "local_news");
-                        // Track image loading during initial phase
                         if (window.loading_state != null && window.loading_state.initial_phase) window.loading_state.pending_images++;
-                        // Force immediate loading for reused images (don't defer) since they're already visible
                         window.image_manager.load_image_async(existing, thumbnail_url, target_w, target_h, true);
                         return;
                     } else {
                     }
             }
 
-            // Skip filtering for saved articles - they should always be displayed regardless of source
+            // Saved articles should always display regardless of source
             bool is_saved_view = (window.prefs.category == "saved");
 
             if (!is_saved_view) {
-                // Use CategoryManager for category filtering
                 if (!window.category_manager.should_display_article(category_id)) {
                     if (debug_enabled()) {
                         warning("Article filtered by category: view=%s article_cat=%s title=%s",
@@ -402,27 +386,18 @@ namespace Managers {
                     return;
                 }
 
-                // Use SourceManager for source filtering
                 if (!window.source_manager.should_display_article(url, category_id)) {
                     return;
                 }
             }
 
-            // Add articles immediately
-            add_item_immediate_to_column(title, url, thumbnail_url, category_id, null, final_source_name, false, published, snippet);
+            add_item_immediate_to_column(title, url, thumbnail_url, category_id, null, final_source_name, false, published, snippet, myfeed_row_key_hint);
         }
 
-        public void add_item_immediate_to_column(string title, string url, string? thumbnail_url, string category_id, string? original_category = null, string? source_name = null, bool bypass_limit = false, string? published = null, string? snippet = null) {
-            // Make this article's feed-provided snippet and published date
-            // available as fallbacks for ArticleSnippetService, which
-            // live-fetches the article's own page and falls back to
-            // whatever matches this URL in article_buffer when that fetch
-            // fails, comes back empty, or (for the date) simply doesn't
-            // expose a recognizable published-date tag on the page itself.
-            // Without this, article_buffer was only ever populated by the
-            // "load more" paths - never for the first batch of articles
-            // shown when a category loads, which includes the hero card and
-            // is exactly where a missing preview/date was most visible.
+        public void add_item_immediate_to_column(string title, string url, string? thumbnail_url, string category_id, string? original_category = null, string? source_name = null, bool bypass_limit = false, string? published = null, string? snippet = null, string? myfeed_row_key_hint = null) {
+            // Buffer this article's snippet/published date as a fallback for
+            // ArticleSnippetService, which live-fetches the article page and
+            // falls back to article_buffer when that fetch fails or is incomplete.
             bool has_snippet = snippet != null && snippet.length > 0;
             bool has_published = published != null && published.length > 0;
             if ((has_snippet || has_published) && article_buffer != null) {
@@ -431,20 +406,18 @@ namespace Managers {
                 article_buffer.add(buffered_item);
             }
 
-            // Decode HTML entities in title (e.g., &mdash; → —, &amp; → &)
             string decoded_title = stripHtmlUtils.strip_html(title);
 
             string check_category = original_category ?? window.prefs.category;
 
-            // Use helper to check if category has article limits
-            if (is_limited_category(check_category) && !bypass_limit) {
+            // My Feed is exempt here too - see add_item() above.
+            if (is_limited_category(check_category) && !bypass_limit && window.prefs.category != "myfeed") {
                 lock (articles_shown) {
                     if (articles_shown >= INITIAL_ARTICLE_LIMIT) {
                         if (title == null || url == null) {
                             return;
                         }
 
-                        // Queue overflow article using helper
                         string normalized_src = normalize_source_name(source_name, category_id, url);
                         if (queue_overflow_article(title, url, thumbnail_url, category_id, normalized_src, published)) {
                             if (!load_more_button_visible) {
@@ -460,15 +433,12 @@ namespace Managers {
             
             bool should_be_hero = false;
             if (window.prefs.category == "saved") {
-                // Saved articles: skip hero, display as regular cards
                 should_be_hero = false;
             } else if (window.prefs.category == "topten") {
                 should_be_hero = (topten_hero_count < 2);
             } else if (window.prefs.category == "frontpage") {
-                // For frontpage, only make the first article a hero (same as other categories)
                 should_be_hero = !featured_used;
             } else if (window.category_manager.is_rssfeed_view()) {
-                // Individual RSS feeds: skip hero, go straight to carousel/columns for adaptive layout
                 should_be_hero = false;
             } else if (!featured_used) {
                 should_be_hero = true;
@@ -515,16 +485,11 @@ namespace Managers {
                     published
                 );
 
-                // Populate the hero's snippet line via the existing on-demand
-                // preview service (same one articlePane uses), rather than
-                // parsing feed/API responses again ourselves. Skipped for Top
-                // Ten: its stacked picture-over-text layout only has room
-                // for the title.
+                // Skipped for Top Ten: its stacked layout only has room for the title.
                 if (window.prefs.category != "topten") {
                     ArticleSnippetService.attach_hero_snippet(hero_card, url, source_name, article_buffer);
                 }
 
-                // Source badge (logo + name), same as regular article cards.
                 if (category_id != "local_news") {
                     var hero_source_badge = window.build_source_badge_dynamic(source_name, url, category_id);
                     hero_card.overlay.add_overlay(hero_source_badge);
@@ -545,10 +510,8 @@ namespace Managers {
                     if (hero_will_load) {
                     // Hero images are the most prominent feature - always use maximum quality
                     int multiplier = 6;
-                    // Track hero image loading to gate initial content reveal
                     if (window.loading_state != null && window.loading_state.initial_phase) window.loading_state.pending_images++;
                     if (window.image_manager != null) window.image_manager.pending_local_placeholder.set(hero_card.image, category_id == "local_news");
-                    // Force immediate loading for hero images (don't defer) to ensure they load quickly
                     window.image_manager.load_image_async(hero_card.image, thumbnail_url, default_hero_w * multiplier, default_hero_h * multiplier, true);
                     window.image_manager.hero_requests.set(hero_card.image, new HeroRequest(thumbnail_url, default_hero_w * multiplier, default_hero_h * multiplier, multiplier));
                     if (window.view_state != null) {
@@ -564,12 +527,10 @@ namespace Managers {
                     Timeout.add(300, () => { var info = window.image_manager.hero_requests.get(hero_card.image); if (info != null) window.maybe_refetch_hero_for(hero_card.image, info); return false; });
                 }
 
-                // Set metadata for context menu
                 hero_card.source_name = source_name;
                 hero_card.category_id = category_id;
                 hero_card.thumbnail_url = thumbnail_url;
 
-                // Register article for unread count tracking
                 // Note: source_name is already normalized by add_item() before being passed here
                 if (window.article_state_store != null) {
                     window.article_state_store.register_article(_norm, category_id, source_name);
@@ -607,7 +568,6 @@ namespace Managers {
                             if (is_saved) {
                                 window.article_state_store.unsave_article(article_url);
                                 request_show_toast("Removed article from saved");
-                                // animate_save_toggle() updates the Saved badge count itself.
                                 if (window.animation_manager != null) {
                                     window.animation_manager.animate_save_toggle(hero_root, hero_save_ribbon, decoded_title, false);
                                 }
@@ -626,8 +586,6 @@ namespace Managers {
                             } else {
                                 window.article_state_store.save_article(article_url, decoded_title, thumbnail_url, source_name, published);
                                 request_show_toast("Added article to saved");
-                                // Ribbon/pop + fly-to-shelf; the Saved badge count
-                                // only bumps once the ghost actually arrives there.
                                 if (window.animation_manager != null) {
                                     window.animation_manager.animate_save_toggle(hero_root, hero_save_ribbon, decoded_title, true);
                                 }
@@ -665,7 +623,6 @@ namespace Managers {
             featured_carousel_items.size < 5) {
             bool allow_slide = false;
             if (window.prefs.category == "myfeed" && window.prefs.personalized_feed_enabled) {
-                // Custom RSS sources in My Feed come with category_id="myfeed"
                 if (category_id == "myfeed") {
                     allow_slide = true;
                 } else if (featured_carousel_category != null && featured_carousel_category == category_id) {
@@ -681,9 +638,6 @@ namespace Managers {
                     }
                 }
             } else if (window.category_manager.is_rssfeed_view()) {
-                // RSS feed views: allow articles for carousel (for adaptive layout)
-                // Individual RSS feeds have category_id="rssfeed:<feed_url>"
-                // My Feed RSS sources have category_id="myfeed"
                 allow_slide = (category_id.has_prefix("rssfeed:") || category_id == "myfeed");
             } else {
                 allow_slide = (category_id == window.prefs.category);
@@ -692,19 +646,16 @@ namespace Managers {
                 return;
             }
 
-            // Extract display category from source_name if available
             string slide_display_cat = category_id;
             if (slide_display_cat == "frontpage" && source_name != null) {
                 int idx2 = source_name.index_of("##category::");
                 if (idx2 >= 0 && source_name.length > idx2 + 12) slide_display_cat = source_name.substring(idx2 + 12).strip();
             }
 
-            // Ensure carousel exists
             if (hero_carousel == null && window.layout_manager != null && window.layout_manager.featured_box != null) {
                 hero_carousel = new HeroCarousel(window.layout_manager.featured_box);
             }
 
-            // Build category chip and create slide via HeroCarousel
             var slide_chip = window.build_category_chip(slide_display_cat);
             var components = hero_carousel.create_article_slide(
                 decoded_title, url, thumbnail_url, category_id, source_name, slide_chip,
@@ -712,8 +663,6 @@ namespace Managers {
                 published
             );
 
-            // Populate this slide's snippet and source badge the same way as
-            // the primary hero.
             var slide_hero = components.hero;
             if (slide_hero != null) {
                 ArticleSnippetService.attach_hero_snippet(slide_hero, url, source_name, article_buffer);
@@ -725,7 +674,6 @@ namespace Managers {
             var slide = components.slide;
             var slide_image = components.image;
 
-            // Handle image loading (this logic stays in ArticleManager as it coordinates with ImageManager)
             int default_w = window.estimate_content_width();
             int default_h = HeroCarousel.SLIDE_IMAGE_HEIGHT;
             bool slide_will_load = thumbnail_url != null && thumbnail_url.length > 0 &&
@@ -738,12 +686,9 @@ namespace Managers {
                     set_smart_placeholder(slide_image, default_w, default_h, source_name, url);
                 }
             } else {
-                // Carousel slides are prominent features - always use maximum quality
                 int multiplier = IMAGE_QUALITY_MULTIPLIER_HIGH;
-                // Track carousel image loading to gate initial content reveal
                 if (window.loading_state != null && window.loading_state.initial_phase) window.loading_state.pending_images++;
                 if (window.image_manager != null) window.image_manager.pending_local_placeholder.set(slide_image, category_id == "local_news");
-                // Force immediate loading for carousel images (don't defer) to ensure they load quickly
                 window.image_manager.load_image_async(slide_image, thumbnail_url, default_w * multiplier, default_h * multiplier, true);
                 window.image_manager.hero_requests.set(slide_image, new HeroRequest(thumbnail_url, default_w * multiplier, default_h * multiplier, multiplier));
                 string _norm = window.normalize_article_url(url);
@@ -760,8 +705,6 @@ namespace Managers {
 
             featured_carousel_items.add(new ArticleItem(decoded_title, url, thumbnail_url, category_id, source_name));
 
-            // Register article for unread count tracking
-            // Carousel slides 2-5 need to be registered just like the first hero card
             string _norm2 = window.normalize_article_url(url);
             if (window.article_state_store != null) {
                 window.article_state_store.register_article(_norm2, category_id, source_name);
@@ -770,11 +713,94 @@ namespace Managers {
             return;
         }
 
-        // All cards use uniform sizing so columns stay evenly spaced.
-        // Use the column width cached for this layout pass (set once in
-        // LayoutManager.rebuild_columns) rather than recomputing it per-card,
-        // so every card gets identical dimensions even if the reported content
-        // width drifts slightly while articles are still streaming in.
+        if (window.layout_manager == null) {
+            warning("ArticleManager: layout_manager not initialized, cannot place card");
+            return;
+        }
+
+        // My Feed's section rows place this article twice - once in its
+        // source's row, once in its category's row (see
+        // LayoutManager.prepare_myfeed_sections) - since a widget can only
+        // have one parent. Every other view builds exactly one card.
+        if (window.category_manager.is_myfeed_view() && window.layout_manager.is_using_category_sections()) {
+            place_myfeed_article_cards(decoded_title, url, thumbnail_url, category_id, source_name, bypass_limit, published, myfeed_row_key_hint);
+        } else {
+            string card_display_cat = category_id;
+            if (card_display_cat == "frontpage" && source_name != null) {
+                int idx3 = source_name.index_of("##category::");
+                if (idx3 >= 0 && source_name.length > idx3 + 12) card_display_cat = source_name.substring(idx3 + 12).strip();
+            }
+            place_regular_article_card(decoded_title, url, thumbnail_url, category_id, source_name, bypass_limit, published, card_display_cat, false);
+        }
+    }
+
+    // Places one article into My Feed's row-based layout: 0, 1, or 2 cards,
+    // depending on whether the article's category and/or source has a live
+    // row (see LayoutManager.resolve_myfeed_category_key/resolve_myfeed_source_key).
+    private void place_myfeed_article_cards(string decoded_title, string url, string? thumbnail_url, string category_id, string? source_name, bool bypass_limit, string? published, string? myfeed_row_key_hint) {
+        string? cat_key = window.layout_manager.resolve_myfeed_category_key(category_id);
+        string? src_key = window.layout_manager.resolve_myfeed_source_key(myfeed_row_key_hint);
+
+        bool placed = false;
+        // Either placement may legitimately miss a row - skip that half
+        // gracefully rather than falling back to a catch-all.
+        if (cat_key != null && try_take_myfeed_row_slot(cat_key)) {
+            place_regular_article_card(decoded_title, url, thumbnail_url, category_id, source_name, bypass_limit, published, cat_key, true);
+            placed = true;
+        }
+        if (src_key != null && try_take_myfeed_row_slot(src_key)) {
+            place_regular_article_card(decoded_title, url, thumbnail_url, category_id, source_name, bypass_limit, published, src_key, true);
+            placed = true;
+        }
+        if (placed) {
+            if (myfeed_displayed_urls == null) myfeed_displayed_urls = new Gee.HashSet<string>();
+            myfeed_displayed_urls.add(window.normalize_article_url(url));
+        }
+    }
+
+    // Reset once per My Feed fetch (see LayoutManager.prepare_myfeed_sections)
+    // so the badge count reflects only the current build's cards.
+    public void reset_myfeed_displayed_urls() {
+        if (myfeed_displayed_urls == null) myfeed_displayed_urls = new Gee.HashSet<string>();
+        else myfeed_displayed_urls.clear();
+    }
+
+    public Gee.HashSet<string> get_myfeed_displayed_urls() {
+        if (myfeed_displayed_urls == null) myfeed_displayed_urls = new Gee.HashSet<string>();
+        return myfeed_displayed_urls;
+    }
+
+    // Claims one of MYFEED_ROW_CARD_CAP real-card slots for this row key,
+    // returning false once that row is full so the caller skips building
+    // a widget for it. Each row is independent - a full "Guardian" row
+    // doesn't affect the "Technology" row's own budget.
+    private bool try_take_myfeed_row_slot(string row_key) {
+        if (myfeed_row_card_counts == null) myfeed_row_card_counts = new Gee.HashMap<string, int>();
+        int count = myfeed_row_card_counts.has_key(row_key) ? myfeed_row_card_counts.get(row_key) : 0;
+        if (count >= MYFEED_ROW_CARD_CAP) return false;
+        myfeed_row_card_counts.set(row_key, count + 1);
+        return true;
+    }
+
+    // Builds one regular (non-hero, non-carousel) article card and places it
+    // into section_key's section (or the flat grid outside sections mode).
+    // no_fallback_section: when true, an unrecognized section_key means skip
+    // placement (My Feed rows); when false, falls back to Front Page's
+    // "More Stories" catch-all.
+    private void place_regular_article_card(
+        string decoded_title,
+        string url,
+        string? thumbnail_url,
+        string category_id,
+        string? source_name,
+        bool bypass_limit,
+        string? published,
+        string section_key,
+        bool no_fallback_section
+    ) {
+        // Use the column width cached for this layout pass rather than
+        // recomputing per-card, so every card gets identical dimensions even
+        // if the reported content width drifts while articles stream in.
         int col_w = 400;
         if (window.layout_manager != null) {
             col_w = window.layout_manager.cached_col_w > 0
@@ -782,10 +808,8 @@ namespace Managers {
                 : window.layout_manager.estimate_column_width(window.layout_manager.columns_count);
         }
         int img_w = col_w;
-        // Fixed pixel height, not derived from col_w: any computed value is a
-        // vector for cards to end up with different picture heights if col_w
-        // is read at slightly different times as articles stream in. A hard
-        // constant makes the picture area identical on every card, always.
+        // Fixed height, not derived from col_w, so every card's picture area
+        // matches even if col_w is read at slightly different times.
         int img_h = CARD_IMAGE_HEIGHT;
 
         string card_display_cat = category_id;
@@ -807,8 +831,9 @@ namespace Managers {
             col_w,
             img_h,
             chip,
-            card_display_cat,
-            published
+            section_key,
+            published,
+            no_fallback_section
         );
 
         if (category_id != "local_news") {
@@ -828,16 +853,12 @@ namespace Managers {
                         if (window.view_state != null) window.view_state.register_picture_for_url(_norm, article_card.image);
                         card_will_load = false;
                     }
-                
+
             }
-            // In single-source mode, use higher 3x multiplier for crisp quality; in multi-source mode, use 2x initially then 3x
             bool single_source = (window.prefs.preferred_sources != null && window.prefs.preferred_sources.size == 1);
             int multiplier = single_source ? 3 : ((window.loading_state != null && window.loading_state.initial_phase) ? 2 : 3);
-            // Track regular card images in pending_images counter during initial phase
             if (window.loading_state != null && window.loading_state.initial_phase) window.loading_state.pending_images++;
             if (window.image_manager != null) window.image_manager.pending_local_placeholder.set(article_card.image, category_id == "local_news");
-            // Always force image load so animations or initial-phase state
-            // never prevent images from being fetched and shown.
             bool force_load = true;
             window.image_manager.load_image_async(article_card.image, thumbnail_url, img_w * multiplier, img_h * multiplier, force_load);
             if (window.view_state != null) window.view_state.register_picture_for_url(_norm, article_card.image);
@@ -856,22 +877,15 @@ namespace Managers {
             if (was) window.mark_article_viewed(_norm);
         }
 
-        // Set metadata for context menu
         article_card.source_name = source_name;
         article_card.category_id = category_id;
         article_card.thumbnail_url = thumbnail_url;
 
-        // Register article for unread count tracking
-        // Skip registration if bypass_limit is true - these articles were already
-        // registered when added to the overflow queue (lines 131 & 314)
-        // Note: source_name is already normalized by add_item() before being passed here
+        // bypass_limit articles were already registered when queued as overflow.
         if (window.article_state_store != null && !bypass_limit) {
             window.article_state_store.register_article(_norm, category_id, source_name);
         }
 
-        // Capture plain widget locals instead of referencing
-        // article_card.root/save_ribbon inside these callbacks - see
-        // ArticleCard.wire_interactions().
         var card_root = article_card.root;
         var card_save_ribbon = article_card.save_ribbon;
         ArticleCard.wire_interactions(
@@ -893,13 +907,11 @@ namespace Managers {
                     if (is_saved) {
                         window.article_state_store.unsave_article(article_url);
                         request_show_toast("Removed article from saved");
-                        // animate_save_toggle() updates the Saved badge count itself.
                         if (window.animation_manager != null) {
                             window.animation_manager.animate_save_toggle(card_root, card_save_ribbon, decoded_title, false);
                         }
 
                         if (window.prefs.category == "saved") {
-                            // Animate removal of this single card instead of a full reload
                             if (window.animation_manager != null) {
                                         var w = card_root;
                                         string? normalized = null;
@@ -913,8 +925,6 @@ namespace Managers {
                     } else {
                         window.article_state_store.save_article(article_url, decoded_title, thumbnail_url, source_name, published);
                         request_show_toast("Added article to saved");
-                        // Ribbon/pop + fly-to-shelf; the Saved badge count only
-                        // bumps once the ghost actually arrives there.
                         if (window.animation_manager != null) {
                             window.animation_manager.animate_save_toggle(card_root, card_save_ribbon, decoded_title, true);
                         }
@@ -926,7 +936,7 @@ namespace Managers {
 
         if (window.loading_state != null && window.loading_state.initial_phase) window.mark_initial_items_populated();
     }
-        
+
         public void load_more_articles() {
             if (remaining_articles == null || remaining_articles.size == 0) {
                 if (load_more_button_visible) {
@@ -944,8 +954,8 @@ namespace Managers {
             }
             
             int articles_to_load = int.min(10, remaining_articles.size);
-            
-            // Snapshot current card count so we can detect newly appended cards
+
+            // Snapshot current card count to detect newly appended cards.
             int prev_card_count = 0;
             int featured_count = 0;
             if (window != null && window.layout_manager != null) {
@@ -963,14 +973,12 @@ namespace Managers {
 
             for (int i = 0; i < articles_to_load; i++) {
                 // Remove from the front rather than indexing in place: this
-                // queue is now a shared pool that per-category "load more"
-                // (load_more_for_category) can also pull from out of order,
-                // so consumption has to be removal-based everywhere to keep
-                // both flows from stepping on each other.
+                // queue is a shared pool that load_more_for_category() also
+                // pulls from out of order.
                 var article = remaining_articles.remove_at(0);
                 string display_cat = extract_display_category(article);
                 remaining_category_counts.set(display_cat, remaining_category_counts.get(display_cat) - 1);
-                // No need to check seen_urls here - articles were already deduplicated
+                // No need to check seen_urls - articles were already deduplicated
                 // when they were added to remaining_articles queue
                 article_buffer.add(article);
                 add_item_immediate_to_column(article.title, article.url, article.thumbnail_url, article.category_id, null, article.source_name, true, article.published);
@@ -1044,50 +1052,35 @@ namespace Managers {
             if (load_more_button_visible) return;
 
             // Front Page has its own per-category "load more" on each
-            // section's nav button (see LayoutManager.add_section_nav_buttons)
-            // now that its sections give overflow articles somewhere to land
-            // that a single page-bottom button doesn't - so skip the global
-            // button there. Every other limited category still uses the old
-            // flat grid and keeps this as its only "load more" affordance.
+            // section's nav button instead of one global button.
             if (window.prefs.category == "frontpage") return;
 
             if (window.loading_state.loading_container != null && window.loading_state.loading_container.get_visible()) {
                 return;
             }
-            
-            // Remove any end of feed message
+
             request_remove_end_feed_message();
-            
-            // Request UI to show the load more button
             request_show_load_more_button();
             load_more_button_visible = true;
         }
-                
-        // Ensure any existing load-more button is removed and cleared.
+
         public void clear_load_more_button() {
             if (!load_more_button_visible) return;
             request_hide_load_more_button();
             load_more_button_visible = false;
         }
 
-        // Public query so other managers can know whether a load-more
-        // button is currently present. This avoids races where two
-        // managers append conflicting UI elements (button vs end label).
         public bool has_load_more_button() {
             return load_more_button_visible;
         }
 
-        // Public helper to clear all article state and destroy article widgets
         public void clear_articles() {
-            // DON'T clear article tracking - we want to accumulate articles across all categories
-            // for persistent unread counts that survive category switches
-
-            // Clear article buffer
+            // Article tracking (view/save state) is intentionally not cleared
+            // here - unread counts persist across category switches.
             if (article_buffer != null) {
                 article_buffer.clear();
             }
 
-            // Clear remaining articles list
             if (remaining_articles != null) {
                 remaining_articles.clear();
             }
@@ -1095,13 +1088,12 @@ namespace Managers {
                 remaining_category_counts.clear();
             }
             articles_shown = 0;
+            if (myfeed_row_card_counts != null) myfeed_row_card_counts.clear();
 
-            // Clear seen_urls to allow fresh deduplication for new fetch
             if (seen_urls != null) {
                 seen_urls.clear();
             }
 
-            // Clear category tracking maps
             if (category_column_counts != null) {
                 category_column_counts.clear();
             }
@@ -1115,35 +1107,26 @@ namespace Managers {
                 recent_category_queue.clear();
             }
 
-            // Reset counters
             topten_hero_count = 0;
 
-            // Clear featured carousel state
             if (featured_carousel_items != null) {
                 featured_carousel_items.clear();
             }
             featured_carousel_category = null;
             featured_used = false;
 
-            // Remove load more button if present
             clear_load_more_button();
 
-            // CRITICAL: Remove and destroy all article card widgets from the grid
             if (window != null && window.layout_manager != null) {
                 window.layout_manager.clear_columns();
             }
         }
 
-        /**
-         * Reset article manager state for a new fetch.
-         * Call this at the start of fetch_news() to prepare for new content.
-         * Clears articles, stops carousel timer, and resets tracking state.
-         */
+        // Resets state for a new fetch: clears articles, stops the carousel
+        // timer, and resets tracking. Call at the start of fetch_news().
         public void reset_for_new_fetch() {
-            // Clear all articles and widgets
             clear_articles();
 
-            // Stop and clear hero carousel
             if (hero_carousel != null) {
                 hero_carousel.stop_timer();
                 if (hero_carousel.container != null && window.layout_manager.featured_box != null) {
@@ -1152,7 +1135,6 @@ namespace Managers {
                 hero_carousel = null;
             }
 
-            // Reset carousel state
             if (featured_carousel_items != null) {
                 featured_carousel_items.clear();
             }
@@ -1160,7 +1142,6 @@ namespace Managers {
             featured_used = false;
             topten_hero_count = 0;
 
-            // Cancel any pending buffer flush timeout
             if (buffer_flush_timeout_id > 0) {
                 Source.remove(buffer_flush_timeout_id);
                 buffer_flush_timeout_id = 0;
@@ -1173,7 +1154,6 @@ namespace Managers {
 
 
     private void set_smart_placeholder(Gtk.Picture image, int w, int h, string? source_name, string url) {
-        // If explicitly in RSS feed view, always use RSS placeholder
         if (window.category_manager.is_rssfeed_view() && source_name != null && source_name.length > 0) {
             window.set_rss_placeholder_image(image, w, h, source_name);
             return;
@@ -1181,10 +1161,10 @@ namespace Managers {
 
         NewsSource resolved = window.resolve_source(source_name, url);
         NewsSource default_source = window.prefs.news_source;
-        
-        // Check if it resolved to the default source (fallback behavior)
+
+        // A name that doesn't match the resolved default source's own name
+        // means this is actually a custom RSS feed that fell back to the default.
         if (resolved == default_source && source_name != null && source_name.length > 0) {
-            // If the name doesn't match the default source, assume it's a custom RSS feed
             if (!source_name_matches(resolved, source_name)) {
                 window.set_rss_placeholder_image(image, w, h, source_name);
                 return;
@@ -1212,15 +1192,10 @@ namespace Managers {
         featured_carousel_category = null;
     }
 
-    /**
-     * Create an ArticleCard from a hero's data and wire up all handlers.
-     * Used by search to convert hero cards to article cards for display.
-     *
-     * Takes plain data rather than a HeroCard reference since a HeroCard no
-     * longer stays reachable past its own construction (see
-     * HeroCard.wire_interactions()); the caller pulls these values off the
-     * hero's root widget instead.
-     */
+    // Creates an ArticleCard from a hero's data and wires up handlers. Used
+    // by search to convert hero cards to article cards for display. Takes
+    // plain data rather than a HeroCard reference since a HeroCard isn't
+    // reachable past its own construction.
     public ArticleCard create_article_card_from_hero(
         string hero_title,
         string hero_url,
@@ -1250,21 +1225,15 @@ namespace Managers {
             article_card.image.set_paintable(hero_paintable);
         }
 
-        // Preserve metadata
         article_card.source_name = hero_source_name;
         article_card.category_id = hero_category_id;
         article_card.thumbnail_url = hero_thumbnail_url;
 
-        // Wire up application-level handlers
         wire_article_card_handlers(article_card, hero_title, hero_url, hero_thumbnail_url, hero_category_id, hero_source_name);
 
         return article_card;
     }
 
-    /**
-     * Wire up all handlers and registration for an article card
-     * Centralizes the signal connections and state registration logic
-     */
     public void wire_article_card_handlers(
         ArticleCard article_card,
         string title,
@@ -1275,14 +1244,12 @@ namespace Managers {
     ) {
         string norm = window.normalize_article_url(url);
 
-        // Register with ViewStateManager
         if (window.view_state != null) {
             window.view_state.register_picture_for_url(norm, article_card.image);
             window.view_state.normalized_to_url.set(norm, url);
             window.view_state.register_card_for_url(norm, article_card.root);
         }
 
-        // Register with ArticleStateStore
         if (window.article_state_store != null) {
             window.article_state_store.register_article(norm, category_id != null ? category_id : "", source_name);
         }
@@ -1314,7 +1281,6 @@ namespace Managers {
                     bool is_saved = window.article_state_store.is_saved(article_url);
                     if (is_saved) {
                         window.article_state_store.unsave_article(article_url);
-                        // animate_save_toggle() updates the Saved badge count itself.
                         if (window.animation_manager != null) {
                             window.animation_manager.animate_save_toggle(card_root, card_save_ribbon, title, false);
                         }
@@ -1332,8 +1298,6 @@ namespace Managers {
                     } else {
                         window.article_state_store.save_article(article_url, title, thumbnail_url, source_name);
                         request_show_toast("Added article to saved");
-                        // Ribbon/pop + fly-to-shelf; the Saved badge count only
-                        // bumps once the ghost actually arrives there.
                         if (window.animation_manager != null) {
                             window.animation_manager.animate_save_toggle(card_root, card_save_ribbon, title, true);
                         }

--- a/src/managers/headerManager.vala
+++ b/src/managers/headerManager.vala
@@ -226,6 +226,8 @@ public class HeaderManager : GLib.Object {
             case "saved": return "Saved";
             case "general": return "World News";
             case "us": return "US News";
+            case "world": return "World News";
+            case "nation": return "US News";
             case "technology": return "Technology";
             case "business": return "Business";
             case "sports": return "Sports";

--- a/src/managers/imageManager.vala
+++ b/src/managers/imageManager.vala
@@ -16,15 +16,9 @@
  */
 
 
-// Plain data carried into the network-download worker pool. Deliberately a
-// simple GObject with value fields rather than a captured closure: the
-// project's home-grown WorkerPool stores ad-hoc per-call closures and turned
-// out to drop their captured-environment ownership (job_target_destroy_notify
-// was always cleared in the generated code), causing a use-after-free once a
-// queued job actually ran. GLib.ThreadPool<T> only ever creates one long-lived
-// closure (the processing func, over `this`) - per-job state travels as plain
-// fields on this object instead, so there is no per-call closure lifetime to
-// get wrong.
+// Plain data carried into the network-download worker pool, not a captured
+// closure - the home-grown WorkerPool drops captured-closure ownership and
+// use-after-frees once a queued job runs.
 private class ImageDownloadJob : GLib.Object {
     public string url;
     public int target_w;
@@ -47,12 +41,8 @@ private class CachedImageJob : GLib.Object {
     public ImageCache? img_cache;
 }
 
-// Outcome of the worker-thread half of a network image download. Carries
-// only plain data (never a Gtk.Picture or a Gee collection), so it is safe
-// to build entirely on a download_pool thread and hand to the main thread
-// afterwards. `ok == false` means "show the fallback placeholder" - it
-// covers network errors, decode failures, and the oversized-Reddit-image
-// bailout uniformly.
+// Worker-thread download result - plain data only, safe to build off-thread.
+// `ok == false` means "show the fallback placeholder".
 private class DownloadOutcome : GLib.Object {
     public bool ok = false;
     public string? size_key;
@@ -487,18 +477,10 @@ public class ImageManager : GLib.Object {
         if (window.meta_cache != null) {
             var disk_path = window.meta_cache.get_cached_path(url);
             if (disk_path != null) {
-                // PERFORMANCE: decoding + scale/crop of an on-disk cached
-                // thumbnail is real CPU work (JPEG/PNG decode, bilinear
-                // scale). This used to run inline on the caller's thread,
-                // which is the main thread for every card built during
-                // article insertion - on views with many already-cached
-                // thumbnails (Front Page especially, which can have far
-                // more cards than any single-source view) that added up
-                // to several seconds of main-thread work and visible
-                // churn. Do the decode/scale off the main thread instead,
-                // mirroring the pattern already used for network
-                // downloads below: only the final texture/cache write
-                // touches GTK state, via Idle.add.
+                // Decode/scale off the main thread, same as network downloads
+                // below - only the final texture/cache write touches GTK
+                // state, via Idle.add. Decoding cached thumbnails inline adds
+                // up fast on views with many cards.
                 int device_scale = 1;
                 try { device_scale = image.get_scale_factor(); if (device_scale < 1) device_scale = 1; } catch (GLib.Error e) { device_scale = 1; }
 

--- a/src/managers/layoutManager.vala
+++ b/src/managers/layoutManager.vala
@@ -19,6 +19,13 @@
 using Gtk;
 using Gee;
 
+// glibc-specific: forces freed heap pages back to the OS immediately instead
+// of waiting on glibc's own heuristics. Needed because rebuilding My Feed's
+// rows frees up to ~120 full-size card textures at once, which otherwise
+// leaves RSS elevated even though everything was properly freed.
+[CCode (cname = "malloc_trim")]
+private static extern int malloc_trim(size_t pad);
+
 namespace Managers {
 
     public class LayoutManager : GLib.Object {
@@ -51,29 +58,27 @@ namespace Managers {
         public Gtk.Widget? content_area;
 
         // Category-grouped sections (Front Page only). Each section is a
-        // vertical "wrapper" (label + horizontally-scrollable row of cards),
+        // vertical wrapper (label + horizontally-scrollable row of cards),
         // pre-built in a fixed priority order and hidden until its first
-        // card arrives, since articles stream in asynchronously and we don't
-        // want section order to depend on fetch timing.
+        // card arrives, since articles stream in asynchronously.
         public Gtk.Box? category_sections_container;
         public Gtk.Separator? hero_frontpage_separator;
         private bool using_category_sections = false;
         private Gee.HashMap<string, CategorySection>? category_sections;
-        // Card root -> its home section, so search filtering (which
-        // temporarily removes non-matching cards) can put matching cards
-        // back into the section they came from instead of a flat grid.
+        // Ordered section keys for the active mode: FRONTPAGE_SECTION_CATEGORIES
+        // for Front Page, or the interleaved key list from prepare_myfeed_sections()
+        // for My Feed - both modes share the same iteration code over this.
+        private Gee.ArrayList<string>? active_section_order;
+        // Card root -> its home section, so search filtering (which temporarily
+        // removes non-matching cards) can restore them to their own section.
         private Gee.HashMap<Gtk.Widget, CategorySection>? card_home_section;
         // Each section's randomly-rolled top-up target (see
-        // reveal_sections_with_pending_overflow) - rolled once per section
-        // per fetch and cached here so repeated calls (one per queued
-        // overflow article) don't re-roll a different target each time.
+        // reveal_sections_with_pending_overflow), cached so repeated calls
+        // don't re-roll a different target each time.
         private Gee.HashMap<string, int>? section_target_depth;
         private const string MISC_SECTION_KEY = "more";
-        // "headlines", "world", and "nation" are the real category ids the
-        // Paperboy frontpage API sends (confirmed against the cached article
-        // data) - "general"/"us" were a guess based on other fetchers and
-        // don't actually occur here, which is why articles in those
-        // categories were falling through to the "more" catch-all.
+        // These are the actual category ids the Paperboy frontpage API sends;
+        // anything else falls through to the "more" catch-all.
         private static string[] FRONTPAGE_SECTION_CATEGORIES = {
             "headlines", "world", "nation", "politics", "business",
             "technology", "science", "health", "sports", "entertainment",
@@ -81,6 +86,21 @@ namespace Managers {
             "economics",
             "more"
         };
+
+        // The sidebar uses "general"/"us" for World/US news where the
+        // frontpage API uses "world"/"nation" - map to the sidebar's id so
+        // the "..." button's navigation and highlight land on the right
+        // row. Returns null when a category has no sidebar entry at all
+        // (e.g. "headlines"), which hides the button for that row.
+        private static string? sidebar_nav_id_for(string cat) {
+            switch (cat) {
+                case "world": return "general";
+                case "nation": return "us";
+                case "headlines": return null;
+                case MISC_SECTION_KEY: return null;
+                default: return cat;
+            }
+        }
 
         // Adaptive layout tracking (for both RSS feeds and regular categories)
         public uint adaptive_layout_timeout_id = 0;
@@ -94,9 +114,6 @@ namespace Managers {
             window = w;
         }
 
-        /**
-        * Reset adaptive layout tracking counters. Call at start of fetch.
-        */
         public void reset_adaptive_tracking() {
             article_count_for_adaptive = 0;
             if (adaptive_layout_timeout_id > 0) {
@@ -110,45 +127,42 @@ namespace Managers {
             reset_adaptive_tracking();
         }
 
-        /**
-        * Track a regular category article arrival and schedule adaptive layout check.
-        * When article count < 15 and no new articles for 500ms, rebuilds as 2-hero layout.
-        *
-        * @param current_fetch_seq The fetch sequence to validate against
-        */
+        // Schedules an adaptive layout check 400ms after the last article
+        // arrival; if the category ends up with fewer than 15 articles,
+        // rebuilds it as a 2-column hero layout.
         public void track_category_article(uint current_fetch_seq) {
-            // Don't increment counter - we'll check ArticleStateStore instead
-            // to get the actual deduplicated count
-
-            // Cancel any existing timeout and schedule a new one
             if (adaptive_layout_timeout_id > 0) {
                 Source.remove(adaptive_layout_timeout_id);
                 adaptive_layout_timeout_id = 0;
             }
 
-            // Schedule layout check after 400ms of no new articles
-            // Reduced from 500ms to 400ms for faster adaptive layout decision
             adaptive_layout_timeout_id = Timeout.add(400, () => {
                 if (current_fetch_seq != FetchContext.current) {
                     return false;
                 }
 
-                // Get the actual deduplicated article count from ArticleStateStore
                 int actual_count = 0;
                 if (window != null && window.article_state_store != null && window.prefs != null) {
                     actual_count = window.article_state_store.get_total_count_for_category(window.prefs.category);
                 }
 
-                // Check if we need to adapt the layout
-                if (actual_count < 15 && actual_count > 0) {
-                    // Rebuild as 2-column hero layout
+                // Sports runs two concurrent fetches (the normal one plus an
+                // extra sports-desk fetch), which can arrive in uneven
+                // bursts under load - a mid-stream gap here can read as
+                // "fetch done" while more articles are still on the way.
+                // Converting to the sparse-category hero grid hides the
+                // normal hero carousel with nothing to un-hide it once the
+                // rest lands, so Sports always keeps its normal layout
+                // regardless of count.
+                bool is_sports = window != null && window.prefs != null && window.prefs.category == "sports";
+
+                if (actual_count < 15 && actual_count > 0 && !is_sports) {
                     Idle.add(() => {
                         if (current_fetch_seq != FetchContext.current) return false;
                         rebuild_as_category_heroes();
                         return false;
                     });
                 } else {
-                    // No adaptive layout needed, allow normal spinner hiding
                     if (window != null && window.loading_state != null) {
                         window.loading_state.awaiting_adaptive_layout = false;
                         if (window.loading_state.initial_items_populated && window.loading_state.initial_phase) {
@@ -244,10 +258,6 @@ namespace Managers {
             return clampi(col_w, 160, 280);
         }
 
-        /**
-        * Unwrap a Gtk.FlowBox's direct child (a Gtk.FlowBoxChild) down to the
-        * actual card widget it wraps.
-        */
         private Gtk.Widget? unwrap_flow_child(Gtk.Widget? flow_child) {
             if (flow_child == null) return null;
             if (flow_child is Gtk.FlowBoxChild) {
@@ -266,22 +276,15 @@ namespace Managers {
             columns_row.set_max_children_per_line(count);
             columns_row.set_visible(true);
 
-            // Fix the column width for this layout pass so every card created
-            // afterward gets identical dimensions. Computing this per-card instead
-            // (as before) let it drift as the content area's reported width
-            // shifted slightly while articles were still streaming in, so
-            // different cards baked in different image heights.
+            // Fixed once per layout pass so every card gets identical
+            // dimensions, rather than drifting as content width is
+            // re-measured while articles stream in.
             cached_col_w = estimate_column_width(count);
         }
 
-        /**
-        * Prepare layout for a new fetch - clears hero/featured containers and rebuilds columns.
-        * Call this at the start of fetch_news() to reset layout state.
-        *
-        * @param is_topten Whether the current view is Top Ten (uses 4 columns, different hero handling)
-        */
+        // Clears hero/featured containers and rebuilds columns. Call at the
+        // start of fetch_news(). is_topten: Top Ten uses 4 columns, others 3.
         public void prepare_for_new_fetch(bool is_topten) {
-            // Clear featured box children
             if (featured_box != null) {
                 Gtk.Widget? fchild = featured_box.get_first_child();
                 while (fchild != null) {
@@ -292,11 +295,10 @@ namespace Managers {
                 }
             }
 
-            // Restore hero/featured container visibility (may have been hidden by RSS adaptive layout)
+            // Restore visibility in case adaptive layout hid these.
             if (hero_container != null) hero_container.set_visible(true);
             if (featured_box != null) featured_box.set_visible(true);
 
-            // Clear hero_container
             if (hero_container != null) {
                 Gtk.Widget? hchild = hero_container.get_first_child();
                 while (hchild != null) {
@@ -307,51 +309,45 @@ namespace Managers {
                 }
             }
 
-            // For non-topten views, add featured_box back for carousel
             if (!is_topten && hero_container != null && featured_box != null) {
                 hero_container.append(featured_box);
             }
 
-            // Rebuild columns: Top Ten uses a 4-column grid, others use 3
             rebuild_columns(is_topten ? 4 : 3);
 
-            // Front Page groups articles into per-category sections instead
-            // of the flat grid; every other view uses the flat grid as before.
-            bool want_sections = (window != null && window.category_manager != null && window.category_manager.is_frontpage_view());
-            if (want_sections) {
+            // Front Page and My Feed both group articles into per-row
+            // sections instead of the flat grid; every other view uses the
+            // flat grid as before.
+            bool is_frontpage = (window != null && window.category_manager != null && window.category_manager.is_frontpage_view());
+            bool is_myfeed = (window != null && window.category_manager != null && window.category_manager.is_myfeed_view());
+            if (is_frontpage) {
                 prepare_category_sections();
+            } else if (is_myfeed) {
+                prepare_myfeed_sections();
             } else {
                 teardown_category_sections();
             }
         }
 
 
-        /**
-        * Common helper for when categories show less than
-        * 15 to adaptively build hero cards
-        */
+        // Builds adaptive hero cards for categories/feeds with under 15 articles.
         public void rebuild_as_adapative_heroes() {
-            // Hide the hero/featured area since we want all articles in columns
             if (hero_container != null) hero_container.set_visible(false);
             if (featured_box != null) featured_box.set_visible(false);
 
-            // Switch the grid to 2 columns - existing cards reflow in place
             rebuild_columns(2);
 
             if (columns_row == null) return;
 
-            // Apply uniform sizing to all article cards in the grid
             Gtk.Widget? flow_child = columns_row.get_first_child();
             while (flow_child != null) {
                 Gtk.Widget? next = flow_child.get_next_sibling();
                 Gtk.Widget? child = unwrap_flow_child(flow_child);
 
                 if (child != null) {
-                    // Force uniform tall hero card dimensions
                     child.set_size_request(-1, RSS_HERO_CARD_HEIGHT);
                     child.add_css_class("rss-hero-card");
 
-                    // Dive into the card structure to set uniform heights on image and text sections
                     if (child is Gtk.Box) {
                         Gtk.Box card_root = (Gtk.Box) child;
                         Gtk.Widget? card_child = card_root.get_first_child();
@@ -514,10 +510,13 @@ namespace Managers {
                 category_sections_container.remove(child);
                 child = next;
             }
+            malloc_trim(0);
 
             category_sections = new Gee.HashMap<string, CategorySection>();
             card_home_section = new Gee.HashMap<Gtk.Widget, CategorySection>();
             section_target_depth = new Gee.HashMap<string, int>();
+            active_section_order = new Gee.ArrayList<string>();
+            foreach (string cat in FRONTPAGE_SECTION_CATEGORIES) active_section_order.add(cat);
 
             foreach (string cat in FRONTPAGE_SECTION_CATEGORIES) {
                 // Written as if/else rather than a nested ternary: mixing an
@@ -543,8 +542,9 @@ namespace Managers {
                 // section's load-more button queries the value that's
                 // actually on those queued items.
                 string query_cat = (cat == MISC_SECTION_KEY) ? "frontpage" : cat;
+                string? nav_target = sidebar_nav_id_for(cat);
 
-                var section = new CategorySection(window, display_name, query_cat);
+                var section = new CategorySection(window, display_name, query_cat, false, false, null, false, null, nav_target);
                 // Faint divider between Front Page category sections,
                 // matching the hero/score/article dividers (see
                 // .section-divider in style.css). Skipped on the first
@@ -553,6 +553,127 @@ namespace Managers {
                 section.wrapper.add_css_class("frontpage-section-divider");
                 category_sections_container.append(section.wrapper);
                 category_sections.set(cat, section);
+            }
+
+            using_category_sections = true;
+            category_sections_container.set_visible(true);
+            if (hero_frontpage_separator != null) hero_frontpage_separator.set_visible(true);
+            if (columns_row != null) columns_row.set_visible(false);
+        }
+
+        /**
+        * Build (or rebuild) My Feed's row sections: rows alternate between
+        * one per followed built-in source (that source's latest articles,
+        * any category) and one per personalized My Feed category (that
+        * topic's articles, any followed source), in source/category/
+        * source/category... order. The hero carousel above these rows is
+        * untouched - this only replaces the flat grid below it.
+        *
+        * Section key convention: category rows use the bare category_id
+        * (unprefixed, exactly like Front Page) so find_category_section()
+        * and the overflow/load-more machinery keep working unmodified for
+        * them. Source rows use "source:<id>" (see SourceManager.
+        * source_enum_to_id) so they can never collide with a category id.
+        *
+        * Custom RSS feeds opted into My Feed (NewsPreferences.
+        * myfeed_feed_enabled, set from the My Feed Custom Feeds dialog) get
+        * a source row too, keyed "customfeed:<url>" so it can never collide
+        * with a built-in "source:<id>" key or a topic category id - see
+        * resolve_myfeed_source_key(), which matches a custom feed article
+        * (whose source_name is literally its feed URL) against this key.
+        */
+        public void prepare_myfeed_sections() {
+            if (category_sections_container == null) return;
+
+            if (window != null && window.article_manager != null) {
+                window.article_manager.reset_myfeed_displayed_urls();
+            }
+
+            Gtk.Widget? child = category_sections_container.get_first_child();
+            while (child != null) {
+                Gtk.Widget? next = child.get_next_sibling();
+                category_sections_container.remove(child);
+                child = next;
+            }
+            malloc_trim(0);
+
+            category_sections = new Gee.HashMap<string, CategorySection>();
+            card_home_section = new Gee.HashMap<Gtk.Widget, CategorySection>();
+            section_target_depth = new Gee.HashMap<string, int>();
+            active_section_order = new Gee.ArrayList<string>();
+
+            // Source-like rows: built-in enabled sources first, then any
+            // custom RSS feeds opted into My Feed - unified into one
+            // (key, display name) list so both interleave against
+            // categories the same way below.
+            var source_keys = new Gee.ArrayList<string>();
+            var source_names = new Gee.ArrayList<string>();
+            // Parallel to source_keys/source_names: a local bundled/saved
+            // logo file path if one's available, else a network favicon
+            // URL to fetch, else both null (plain text header, as before).
+            var source_logo_files = new Gee.ArrayList<string?>();
+            var source_logo_urls = new Gee.ArrayList<string?>();
+            if (window != null && window.source_manager != null) {
+                foreach (var src in window.source_manager.get_enabled_source_enums()) {
+                    source_keys.add("source:" + SourceManager.source_enum_to_id(src));
+                    source_names.add(SourceManager.get_source_name(src));
+                    source_logo_files.add(SourceUtils.get_source_icon_path(src));
+                    source_logo_urls.add(null);
+                }
+            }
+            if (window != null && window.prefs != null) {
+                var rss_store = Paperboy.RssSourceStore.get_instance();
+                foreach (var feed in rss_store.get_all_sources()) {
+                    if (window.prefs.preferred_source_enabled("custom:" + feed.url) && window.prefs.myfeed_feed_enabled(feed.url)) {
+                        source_keys.add("customfeed:" + feed.url);
+                        source_names.add(feed.name);
+
+                        // Same precedence CardBuilder.build_source_badge_dynamic
+                        // uses for custom sources: a previously-saved local
+                        // favicon file first, network favicon_url otherwise.
+                        string? local_path = null;
+                        if (feed.icon_filename != null && feed.icon_filename.length > 0) {
+                            var data_dir = GLib.Environment.get_user_data_dir();
+                            var candidate = GLib.Path.build_filename(data_dir, "paperboy", "source_logos", feed.icon_filename);
+                            if (GLib.FileUtils.test(candidate, GLib.FileTest.EXISTS)) local_path = candidate;
+                        }
+                        source_logo_files.add(local_path);
+                        source_logo_urls.add(local_path == null ? feed.favicon_url : null);
+                    }
+                }
+            }
+
+            Gee.ArrayList<string> categories = (window != null && window.category_manager != null)
+                ? window.category_manager.get_myfeed_categories()
+                : new Gee.ArrayList<string>();
+
+            int max_len = int.max(source_keys.size, categories.size);
+            for (int i = 0; i < max_len; i++) {
+                if (i < source_keys.size) {
+                    string key = source_keys.get(i);
+                    string display_name = source_names.get(i);
+                    // Built-in sources ("source:<id>") have no single-source
+                    // page to jump to yet; custom feeds do, via the same
+                    // "rssfeed:<url>" id their sidebar entry already uses.
+                    string? nav_target = key.has_prefix("customfeed:")
+                        ? "rssfeed:" + key.substring("customfeed:".length)
+                        : null;
+                    var section = new CategorySection(window, display_name, key, false, false, source_logo_urls.get(i), false, source_logo_files.get(i), nav_target);
+                    section.wrapper.add_css_class("frontpage-section-divider");
+                    category_sections_container.append(section.wrapper);
+                    category_sections.set(key, section);
+                    active_section_order.add(key);
+                }
+                if (i < categories.size) {
+                    string cat = categories.get(i);
+                    string display_name = (window != null) ? window.category_display_name_for(cat) : cat;
+                    string? nav_target = sidebar_nav_id_for(cat);
+                    var section = new CategorySection(window, display_name, cat, false, false, null, false, null, nav_target);
+                    section.wrapper.add_css_class("frontpage-section-divider");
+                    category_sections_container.append(section.wrapper);
+                    category_sections.set(cat, section);
+                    active_section_order.add(cat);
+                }
             }
 
             using_category_sections = true;
@@ -589,6 +710,16 @@ namespace Managers {
             if (columns_row != null) columns_row.set_visible(true);
             category_sections = null;
             card_home_section = null;
+            active_section_order = null;
+            malloc_trim(0);
+        }
+
+        /**
+        * Whether sections mode (Front Page or My Feed rows) is currently
+        * active, as opposed to the flat grid.
+        */
+        public bool is_using_category_sections() {
+            return using_category_sections;
         }
 
         /**
@@ -606,6 +737,50 @@ namespace Managers {
 
             section.add_card(card_root);
             if (card_home_section != null) card_home_section.set(card_root, section);
+        }
+
+        /**
+        * Route an article card into a specific section by its exact key,
+        * with NO catch-all fallback: a key that doesn't correspond to a
+        * live section (e.g. a My Feed row whose source/category the
+        * article doesn't match) simply means "don't place it here",
+        * silently. Used for My Feed's dual source+category placement,
+        * where add_card_to_category_section's Front-Page-specific
+        * "More Stories" fallback would be wrong - dumping an unmatched
+        * article into a misc bucket that doesn't exist in My Feed's model.
+        */
+        public void add_card_to_named_section(string key, Gtk.Widget card_root) {
+            if (!using_category_sections || category_sections == null) return;
+            CategorySection? section = category_sections.get(key);
+            if (section == null) return;
+
+            section.add_card(card_root);
+            if (card_home_section != null) card_home_section.set(card_root, section);
+        }
+
+        /**
+        * Resolve a My Feed article's category_id to its section key, if
+        * that category currently has a live row (i.e. it's one of the
+        * user's personalized My Feed categories). Returns null otherwise
+        * so the caller can skip that placement.
+        */
+        public string? resolve_myfeed_category_key(string category_id) {
+            if (!using_category_sections || category_sections == null) return null;
+            return category_sections.has_key(category_id) ? category_id : null;
+        }
+
+        /**
+        * Confirm a My Feed row key (e.g. "source:guardian" or
+        * "customfeed:<url>") corresponds to a currently-live row. The key is
+        * resolved by the caller (ArticleManager.add_item(), from
+        * source_name/category_id before SourceManager.normalize_source_name
+        * rewrites source_name into a display name) rather than fuzzy-matched
+        * here against the already-mutated name.
+        */
+        public string? resolve_myfeed_source_key(string? row_key_hint) {
+            if (!using_category_sections || category_sections == null) return null;
+            if (row_key_hint == null || row_key_hint.length == 0) return null;
+            return category_sections.has_key(row_key_hint) ? row_key_hint : null;
         }
 
         /**
@@ -686,10 +861,17 @@ namespace Managers {
         }
 
         public void reveal_sections_with_pending_overflow() {
-            if (!using_category_sections || category_sections == null) return;
+            if (!using_category_sections || category_sections == null || active_section_order == null) return;
             if (window == null || window.article_manager == null) return;
 
-            foreach (string cat in FRONTPAGE_SECTION_CATEGORIES) {
+            foreach (string cat in active_section_order) {
+                // My Feed source rows ("source:<id>") and custom feed rows
+                // ("customfeed:<url>") have no overflow/load-more backing
+                // yet - remaining_count_for_category only knows real
+                // category ids, so skip them here rather than asking it a
+                // question it has no answer for.
+                if (cat.has_prefix("source:") || cat.has_prefix("customfeed:")) continue;
+
                 CategorySection? section = category_sections.get(cat);
                 if (section == null) continue;
 
@@ -784,7 +966,8 @@ namespace Managers {
             int img_h,
             Gtk.Widget chip,
             string? section_category_id = null,
-            string? published = null
+            string? published = null,
+            bool no_fallback_section = false
         ) {
             var article_card = new ArticleCard(
                 title,
@@ -804,7 +987,11 @@ namespace Managers {
             // appends straight to the grid, which handles row/column placement
             // automatically.
             if (using_category_sections && section_category_id != null) {
-                add_card_to_category_section(section_category_id, article_card.root);
+                if (no_fallback_section) {
+                    add_card_to_named_section(section_category_id, article_card.root);
+                } else {
+                    add_card_to_category_section(section_category_id, article_card.root);
+                }
             } else if (columns_row != null) {
                 columns_row.append(article_card.root);
             }
@@ -829,8 +1016,8 @@ namespace Managers {
             var original_cards = new Gee.ArrayList<Gtk.Widget>();
 
             if (using_category_sections) {
-                if (category_sections == null) return original_cards;
-                foreach (string cat in FRONTPAGE_SECTION_CATEGORIES) {
+                if (category_sections == null || active_section_order == null) return original_cards;
+                foreach (string cat in active_section_order) {
                     CategorySection? section = category_sections.get(cat);
                     if (section == null) continue;
                     Gtk.Widget? child = section.row.get_first_child();
@@ -992,8 +1179,8 @@ namespace Managers {
         public GLib.ListModel? get_cards_for_iteration() {
             if (using_category_sections) {
                 var store = new GLib.ListStore(typeof(Gtk.Widget));
-                if (category_sections != null) {
-                    foreach (string cat in FRONTPAGE_SECTION_CATEGORIES) {
+                if (category_sections != null && active_section_order != null) {
+                    foreach (string cat in active_section_order) {
                         CategorySection? section = category_sections.get(cat);
                         if (section == null) continue;
                         Gtk.Widget? child = section.row.get_first_child();

--- a/src/managers/loadingStateManager.vala
+++ b/src/managers/loadingStateManager.vala
@@ -24,10 +24,8 @@ namespace Managers {
 public class LoadingStateManager : GLib.Object {
     private weak NewsWindow window;
 
-    // Fired from show_loading_spinner()/hide_loading_spinner() - the
-    // existing start/stop pair every fetch path in FetchNewsController
-    // already calls - so header UI (the refresh button's icon<->spinner
-    // swap) can track fetch activity without its own separate plumbing.
+    // Fired from show_loading_spinner()/hide_loading_spinner() so header UI
+    // (the refresh button's icon<->spinner swap) can track fetch activity.
     public signal void fetch_started();
     public signal void fetch_finished();
 
@@ -63,12 +61,8 @@ public class LoadingStateManager : GLib.Object {
         window = w;
     }
 
-    /**
-     * Begin a new fetch - resets initial phase state and shows loading spinner.
-     * Call this at the start of fetch_news() to initialize loading state.
-     */
+    // Call at the start of fetch_news() to reset initial-phase state and show the spinner.
     public void begin_fetch() {
-        // Reset initial-phase gating state
         initial_phase = true;
         hero_image_loaded = false;
         pending_images = 0;
@@ -76,12 +70,10 @@ public class LoadingStateManager : GLib.Object {
         network_failure_detected = false;
         initial_phase_start_time = GLib.get_monotonic_time();
 
-        // Clear image cache at startup to rule out stale cache data
         if (window.image_cache != null) window.image_cache.clear();
 
-        // Don't reset awaiting_adaptive_layout - it may have been set before begin_fetch()
+        // Don't reset awaiting_adaptive_layout - it may already be set from before begin_fetch()
 
-        // Cancel any pending initial reveal timeouts
         if (initial_reveal_timeout_id > 0) {
             Source.remove(initial_reveal_timeout_id);
             initial_reveal_timeout_id = 0;
@@ -91,30 +83,22 @@ public class LoadingStateManager : GLib.Object {
             absolute_reveal_timeout_id = 0;
         }
 
-        // Set an absolute maximum timeout - but only reveal if content has actually arrived
-        // This prevents showing a blank white area when content takes longer than expected
-        // Reduced from 8s to 4s for faster perceived performance
+        // Absolute max wait before giving up on content and revealing anyway (avoids blank screen).
         absolute_reveal_timeout_id = GLib.Timeout.add(4000, () => {
-            // Only reveal if we have content; otherwise keep spinner visible
             if (initial_items_populated) {
                 reveal_initial_content();
             }
-            // Don't clear the timeout ID here - let it be cleared by reveal_initial_content
-            // or when content eventually arrives
             return false;
         });
 
-        // Hide any previous error message
         hide_error_message();
-
-        // Show loading spinner
         show_loading_spinner();
     }
 
     public void show_loading_spinner() {
         fetch_started();
         if (loading_container != null && loading_spinner != null && loading_label != null) {
-            // Remove "No more articles" message when starting a new load
+            // Remove "No more articles" message from the previous load, if any
             var children = window.content_box.observe_children();
             for (uint i = 0; i < children.get_n_items(); i++) {
                 var child = children.get_item(i) as Gtk.Widget;
@@ -128,10 +112,8 @@ public class LoadingStateManager : GLib.Object {
                 }
             }
 
-            // Hide My Feed instructions if switching away from My Feed
             update_personalization_ui();
 
-            // If we're fetching Local News, show a more specific message
             var prefs_local = NewsPreferences.get_instance();
             if (prefs_local != null && prefs_local.category == "local_news") {
                 loading_label.set_text("Loading local news...");
@@ -154,7 +136,6 @@ public class LoadingStateManager : GLib.Object {
             update_personalization_ui();
             update_local_news_ui();
 
-            // Save article tracking and refresh sidebar badges after content is loaded
             if (window.article_state_store != null) {
                 window.article_state_store.save_article_tracking_to_disk();
             }
@@ -166,8 +147,7 @@ public class LoadingStateManager : GLib.Object {
                 window.article_manager.show_load_more_button();
             } else if (window.article_manager.remaining_articles == null || window.article_manager.remaining_articles.size == 0) {
                 Timeout.add(800, () => {
-                    // Safety check: window may have been destroyed (weak reference)
-                    if (window == null) return false;
+                    if (window == null) return false; // weak ref; window may be gone
                     if (loading_container == null || !loading_container.get_visible()) {
                         show_end_of_feed_message();
                     }
@@ -193,10 +173,7 @@ public class LoadingStateManager : GLib.Object {
     public void hide_error_message() {
         if (error_message_box != null) {
             error_message_box.set_visible(false);
-            // CRITICAL: Restore main content visibility when hiding error
-            // show_error_message() hides main_content_container, so we must restore it
-            // This fixes the dead-end issue where articles are invisible after clicking
-            // a new category following an RSS timeout error
+            // show_error_message() hides main_content_container - restore it or articles stay invisible
             if (window.main_content_container != null && !initial_phase) {
                 window.main_content_container.set_visible(true);
             }
@@ -210,12 +187,13 @@ public class LoadingStateManager : GLib.Object {
         bool is_myfeed = prefs.category == "myfeed";
         bool has_personalized = prefs.personalized_categories != null && prefs.personalized_categories.size > 0;
 
-        // Check if there are any custom RSS sources enabled
+        // Must match what fetchNewsController.vala actually fetches for My Feed
+        // (enabled AND opted into My Feed), so the message doesn't disagree with the view.
         bool has_custom_rss = false;
         var rss_store = Paperboy.RssSourceStore.get_instance();
         var all_custom = rss_store.get_all_sources();
         foreach (var src in all_custom) {
-            if (prefs.preferred_source_enabled("custom:" + src.url)) {
+            if (prefs.preferred_source_enabled("custom:" + src.url) && prefs.myfeed_feed_enabled(src.url)) {
                 has_custom_rss = true;
                 break;
             }
@@ -223,7 +201,6 @@ public class LoadingStateManager : GLib.Object {
 
         bool show_message = false;
         if (is_myfeed) {
-            // Show message if personalized feed is disabled (no content will be fetched regardless of sources)
             if (!enabled) {
                 if (personalized_message_label != null) personalized_message_label.set_text("Personalized feed is disabled.");
                 if (personalized_message_sub_label != null) {
@@ -233,7 +210,6 @@ public class LoadingStateManager : GLib.Object {
                 if (personalized_message_action != null) personalized_message_action.set_visible(true);
                 show_message = true;
             } else if (prefs.myfeed_custom_only && !has_custom_rss) {
-                // Custom sources only mode is enabled but no RSS sources are followed
                 if (personalized_message_label != null) personalized_message_label.set_text("No custom RSS sources followed.");
                 if (personalized_message_sub_label != null) {
                     personalized_message_sub_label.set_text("You've enabled 'Custom sources only' mode. Follow and enable RSS feeds by clicking the button below or open the main menu (☰) → Preferences → 'Sources' tab.");
@@ -258,28 +234,25 @@ public class LoadingStateManager : GLib.Object {
 
         if (personalized_message_box != null) personalized_message_box.set_visible(show_message);
 
-        // Hide main content when showing the overlay (regardless of initial_phase)
-        // Also keep it hidden if we're waiting for adaptive layout to complete
-        // CRITICAL: Also keep it hidden during initial_phase to prevent blank cards
+        // Keep main content hidden while showing the overlay, or during initial_phase/adaptive layout
+        // to avoid a flash of blank cards.
         if (window.main_content_container != null) {
             if (show_message) {
                 window.main_content_container.set_visible(false);
             } else if (!awaiting_adaptive_layout && !initial_phase) {
                 window.main_content_container.set_visible(true);
             }
-            // If awaiting_adaptive_layout OR initial_phase, keep it hidden (don't change visibility)
         }
 
         if (loading_container != null && show_message) {
             loading_container.set_visible(false);
 
-            // Cancel the initial reveal timeout to prevent error overlay from showing
             if (initial_reveal_timeout_id > 0) {
                 Source.remove(initial_reveal_timeout_id);
                 initial_reveal_timeout_id = 0;
             }
 
-            // Mark as populated and exit initial phase to prevent timeout from triggering error
+            // Exit initial phase so the reveal timeout doesn't fire an error over this message
             initial_items_populated = true;
             initial_phase = false;
         }
@@ -298,7 +271,6 @@ public class LoadingStateManager : GLib.Object {
         needs_location = is_local && !has_location;
 
         if (local_news_message_box != null) local_news_message_box.set_visible(needs_location);
-        // Only show main content if not in initial phase and not awaiting adaptive layout
         if (!initial_phase && !awaiting_adaptive_layout && window.main_content_container != null) {
             window.main_content_container.set_visible(!needs_location);
         }
@@ -306,7 +278,6 @@ public class LoadingStateManager : GLib.Object {
 
     public void reveal_initial_content() {
         if (!initial_phase) return;
-        // Don't reveal if we're still waiting for adaptive layout to complete
         if (awaiting_adaptive_layout) return;
 
         initial_phase = false;
@@ -323,11 +294,9 @@ public class LoadingStateManager : GLib.Object {
         bool pvis = personalized_message_box != null ? personalized_message_box.get_visible() : false;
         bool lvis = local_news_message_box != null ? local_news_message_box.get_visible() : false;
         if (!pvis && !lvis) {
-            // Prepare and trigger animated reveal so we don't flash already-visible content.
             trigger_initial_reveals();
         }
 
-        // Small delay to run non-visual housekeeping after initial reveal
         Timeout.add(180, () => {
             if (window.image_manager != null) window.image_manager.upgrade_images_after_initial();
             if (window.article_state_store != null) {
@@ -340,12 +309,8 @@ public class LoadingStateManager : GLib.Object {
         });
     }
 
-    /**
-     * Prepare initial visual state for the first visible cards and play
-     * libadwaita-powered entrance animations. This applies an invisible/offset
-     * starting state before making the main content visible so there is no
-     * flash, and then runs the staggered animations.
-     */
+    // Applies an invisible/offset starting state to the first visible cards before making
+    // main content visible, then plays the staggered entrance animations - avoids a flash.
     private void trigger_initial_reveals() {
         if (window == null || window.layout_manager == null || window.animation_manager == null) return;
 
@@ -365,8 +330,6 @@ public class LoadingStateManager : GLib.Object {
             }
         }
 
-        // Apply the invisible/offset starting state so when the container
-        // becomes visible there is no intermediate flash.
         int initial_margin = 18;
         for (uint i = 0; i < cards.size; i++) {
             var w = cards.get((int)i) as Gtk.Widget;
@@ -378,13 +341,12 @@ public class LoadingStateManager : GLib.Object {
 
         if (window.main_content_container != null) window.main_content_container.set_visible(true);
 
-        // Use Idle so GTK has applied the initial state before animations start
+        // Idle so GTK has applied the initial state before animations start
         GLib.Idle.add(() => {
             int limit = Managers.ArticleManager.INITIAL_ARTICLE_LIMIT;
             uint per_item_ms = 32;
             uint animate_index = 0;
 
-            // First animate featured area (keep as primary top items)
             if (window.layout_manager != null && window.layout_manager.featured_box != null) {
                 var f = window.layout_manager.featured_box;
                 var fc = f.get_first_child();
@@ -395,8 +357,7 @@ public class LoadingStateManager : GLib.Object {
                 }
             }
 
-            // Then animate the grid in row-major order (left-to-right, top-to-bottom).
-            // The grid is a real Gtk.FlowBox, so insertion order already is row-major order.
+            // The grid is a Gtk.FlowBox, so insertion order is already row-major.
             if (window.layout_manager != null && window.layout_manager.columns_row != null) {
                 var child = window.layout_manager.columns_row.get_first_child();
                 while (child != null && (int) animate_index < limit) {
@@ -413,28 +374,26 @@ public class LoadingStateManager : GLib.Object {
     public void mark_initial_items_populated() {
         initial_items_populated = true;
 
-        // Reset timeout every time a new article is added during initial phase
-        // Use a short timeout (500ms) after each article - if no more articles arrive
-        // within that window, we reveal. This ensures we wait for the batch to complete.
+        // Reset the timeout on each new article so we wait for the whole batch to land
+        // before revealing, instead of revealing after the very first one.
         if (initial_phase) {
             if (initial_reveal_timeout_id > 0) {
                 Source.remove(initial_reveal_timeout_id);
             }
-            // Short delay after last article to allow any remaining articles in the batch
-            // Reduced from 500ms to 300ms for faster reveal
             initial_reveal_timeout_id = GLib.Timeout.add(300, () => {
-                // Clear the timeout ID since we're now executing
                 initial_reveal_timeout_id = 0;
 
-                // Don't reveal if we're waiting for adaptive layout check to complete
                 if (awaiting_adaptive_layout) {
                     return false;
                 }
 
-                // Only reveal if we have a reasonable number of articles
-                // This prevents revealing with just 1-2 articles when more are expected
+                // Front Page/My Feed route cards through category_sections_ rows, not
+                // columns_row, so both need counting or this always undercounts those views.
                 int article_count = 0;
-                    if (window.layout_manager != null && window.layout_manager.columns_row != null) {
+                    if (window.layout_manager != null && window.layout_manager.is_using_category_sections()) {
+                        var model = window.layout_manager.get_cards_for_iteration();
+                        if (model != null) article_count += (int) model.get_n_items();
+                    } else if (window.layout_manager != null && window.layout_manager.columns_row != null) {
                         var child = window.layout_manager.columns_row.get_first_child();
                         while (child != null) {
                             article_count++;
@@ -450,10 +409,9 @@ public class LoadingStateManager : GLib.Object {
                         }
                     }
 
-                // Reveal if we have at least 3 articles, or if we've been waiting a while
                 if (article_count >= 3) {
-                    // CRITICAL: Don't use reveal_initial_content() - it exits early if initial_phase is false
-                    // After RSS timeout, initial_phase is already false, so directly show the container
+                    // Not reveal_initial_content() - it exits early once initial_phase is
+                    // already false, which it can be here after an RSS timeout.
                         initial_phase = false;
                         hero_image_loaded = false;
                         if (initial_reveal_timeout_id > 0) {
@@ -465,18 +423,14 @@ public class LoadingStateManager : GLib.Object {
                             absolute_reveal_timeout_id = 0;
                         }
                         hide_loading_spinner();
-                        // Use the reveal helper so animations start without flashing
                         trigger_initial_reveals();
                 } else {
-                    // Not enough articles yet - set a longer timeout
-                    // Reduced from 2000ms to 1200ms for faster reveal with few articles
+                    // Too few articles yet; give it more time before revealing anyway.
                     initial_reveal_timeout_id = GLib.Timeout.add(1200, () => {
                         initial_reveal_timeout_id = 0;
-                        // Don't reveal if waiting for adaptive layout
                         if (awaiting_adaptive_layout) {
                             return false;
                         }
-                        // CRITICAL: Same fix here
                             initial_phase = false;
                             hero_image_loaded = false;
                             hide_loading_spinner();
@@ -489,11 +443,6 @@ public class LoadingStateManager : GLib.Object {
         }
     }
 
-    /**
-     * Called when an image finished being set (success or fallback). During the
-     * initial phase we decrement the pending counter and reveal the UI when all
-     * initial items are populated and no pending image loads remain.
-     */
     public void on_image_loaded(Gtk.Picture image) {
         if (!initial_phase) return;
         if (window.image_manager != null && window.image_manager.hero_requests.get(image) != null) {
@@ -502,7 +451,6 @@ public class LoadingStateManager : GLib.Object {
         if (pending_images > 0) pending_images--;
 
         if (initial_items_populated && pending_images == 0) {
-            // Don't reveal if waiting for adaptive layout
             if (!awaiting_adaptive_layout) {
                 reveal_initial_content();
             }
@@ -529,16 +477,13 @@ public class LoadingStateManager : GLib.Object {
                 }
             }
 
-            // Note: load_more_button is now managed by ArticleManager, so we don't need to remove it here
             var end_label = new Gtk.Label("<b>No more articles</b>");
             end_label.set_use_markup(true);
             end_label.add_css_class("dim-label");
             end_label.set_margin_top(20);
             end_label.set_margin_bottom(20);
             end_label.set_halign(Gtk.Align.CENTER);
-            // Don't show the end-of-feed label if the ArticleManager
-            // has (or is about to show) a Load More button to avoid
-            // the visual overlap where both appear together.
+            // Avoid showing this alongside a Load More button
             if (window.article_manager != null && window.article_manager.has_load_more_button()) {
                 return;
             }

--- a/src/managers/sidebarManager.vala
+++ b/src/managers/sidebarManager.vala
@@ -397,7 +397,16 @@ public class SidebarManager : GLib.Object {
             if (!window.prefs.personalized_feed_enabled) {
                 return 0;
             }
-            return window.article_state_store.get_unread_count_for_myfeed(window.prefs);
+            var displayed = window.article_manager != null ? window.article_manager.get_myfeed_displayed_urls() : null;
+            // Placeholder until My Feed has actually been built this
+            // session (is_category_visited persists across app restarts,
+            // but displayed_urls is reset fresh each launch - gating on the
+            // persisted flag would skip the placeholder even when there's
+            // no real data yet this session).
+            if (displayed == null || displayed.size == 0) {
+                return -1;
+            }
+            return window.article_state_store.get_unread_count_for_myfeed(displayed);
         }
 
         // Local News: use category-based unread count (articles registered
@@ -653,19 +662,25 @@ public class SidebarManager : GLib.Object {
      */
     public void update_badge_for_category(string category_id) {
         int unread_count = 0;
+        // My Feed has no real count until it's actually been built this
+        // session (displayed_urls is reset fresh each launch, unlike the
+        // persisted is_category_visited flag popular categories use) -
+        // keep showing "--" until then.
+        bool myfeed_has_data = false;
         if (window.article_state_store != null) {
-            // For myfeed, use filtered count that only includes enabled sources
             if (category_id == "myfeed") {
-                unread_count = window.article_state_store.get_unread_count_for_myfeed(window.prefs);
+                var displayed = window.article_manager != null ? window.article_manager.get_myfeed_displayed_urls() : null;
+                myfeed_has_data = displayed != null && displayed.size > 0;
+                unread_count = window.article_state_store.get_unread_count_for_myfeed(displayed);
             } else {
                 unread_count = window.article_state_store.get_unread_count_for_category(category_id);
             }
         }
         category_unread_counts.set(category_id, unread_count);
 
-        // For popular categories, only update badge if user has visited it
-        // Otherwise keep showing "--" placeholder
-        if (is_popular_category(category_id) && !is_category_visited(category_id)) {
+        if (category_id == "myfeed") {
+            if (!myfeed_has_data) return;
+        } else if (is_popular_category(category_id) && !is_category_visited(category_id)) {
             // Don't update - keep placeholder
             return;
         }

--- a/src/managers/sourceManager.vala
+++ b/src/managers/sourceManager.vala
@@ -19,15 +19,8 @@ using GLib;
 using Gee;
 using Xml;
 
-/*
- *SourceManager - Centralized source management
- *
- * This class provides a single source of truth for:
- * - Which sources are enabled
- * - Source capabilities (categories, special behavior)
- * - Source inference from URLs
- * - Source validation and filtering
- */
+// Single source of truth for which sources are enabled, their capabilities,
+// URL-based source inference, and source filtering/validation.
 
 // Callback for RSS feed addition
 public delegate void RssFeedAddCallback(bool success, string feed_name);
@@ -162,11 +155,13 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
         }
     }
 
-    // Get list of enabled sources as NewsSource enums
+    // Filters out "custom:<url>" entries first - source_id_to_enum() falls back to
+    // GUARDIAN for unrecognized ids, which would otherwise map every custom feed to a bogus GUARDIAN entry.
     public ArrayList<NewsSource> get_enabled_source_enums() {
         var result = new ArrayList<NewsSource>();
         var enabled = get_enabled_sources();
         foreach (var src_id in enabled) {
+            if (src_id.has_prefix("custom:")) continue;
             result.add(source_id_to_enum(src_id));
         }
         return result;
@@ -581,13 +576,8 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
             return true;
         }
 
-        // Sports also always gets shown regardless of enabled-source filtering:
-        // the persistent Paperboy backend sports supplement (see
-        // PaperboyFetcher.fetch_paperboy_sports) fills the category for users
-        // whose enabled sources don't have a dedicated sports desk, and its
-        // articles come from third-party sites that don't map to any
-        // built-in source id, so the enabled-source check below would
-        // otherwise always filter them out.
+        // Sports articles come from the Paperboy backend's sports supplement, which pulls from
+        // third-party sites that don't map to any built-in source id, so skip the enabled-source check.
         if (category == "sports") {
             return true;
         }
@@ -627,8 +617,7 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
         return true;
     }
 
-    // Add an RSS feed with robust metadata discovery
-    // This method fetches the feed, parses it to get the real title, and attempts to fetch a favicon
+    // Fetches the feed to discover its real title and a favicon before adding it.
     public void add_rss_feed_with_discovery(string feed_url, string? user_provided_name, owned RssFeedAddCallback callback) {
         new Thread<void*>("rss-add-with-discovery", () => {
             string final_name = user_provided_name != null && user_provided_name.length > 0 ? user_provided_name : "";
@@ -638,7 +627,6 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
             try {
                 host = UrlUtils.extract_host_from_url(feed_url);
 
-                // Step 1: Try to fetch the RSS feed and extract the title
                 if (final_name.length == 0) {
                     try {
                         var msg = new Soup.Message("GET", feed_url);
@@ -650,7 +638,6 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                         if (status == Soup.Status.OK && response != null) {
                             string body = (string) response.get_data();
 
-                            // Try to extract feed title from RSS/Atom XML
                             final_name = extract_feed_title_from_xml(body);
 
                             if (final_name.length == 0 && host != null) {
@@ -662,15 +649,12 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                     }
                 }
 
-                // Fallback to hostname if still no name
                 if (final_name.length == 0 && host != null) {
                     final_name = host.replace("www.", "");
                 } else if (final_name.length == 0) {
                     final_name = feed_url;
                 }
 
-                // Step 2: Try to get a logo/favicon
-                // Priority 1: Check if we already have metadata for this source
                 string? existing_display_name = null;
                 bool force_update_meta = false;
                 if (host != null) {
@@ -678,20 +662,15 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                     string? existing_filename = null;
                     SourceMetadata.get_source_info_by_url(feed_url, out existing_display_name, out existing_logo_url, out existing_filename);
 
-                    // If we have existing display name from source_info, decide whether
-                    // to keep it or prefer the newly-discovered feed title. We prefer
-                    // the discovered title when the existing name looks like a domain
-                    // (contains a dot and no spaces) and the discovered title appears
-                    // more human (contains a space or has uppercase letters).
+                    // Prefer the newly discovered title over an existing domain-like name
+                    // (e.g. "example.com") when the discovered one looks more human.
                     if (existing_display_name != null && existing_display_name.length > 0 && final_name != null && final_name.length > 0) {
                         bool existing_is_domain = existing_display_name.index_of(".") >= 0 && existing_display_name.index_of(" ") < 0;
                         string final_name_lower = final_name.down();
                         bool new_is_more_human = (final_name.index_of(" ") >= 0) || (final_name_lower != null && final_name != final_name_lower);
                         if (existing_is_domain && new_is_more_human) {
-                            // Keep our discovered final_name and request metadata overwrite
                             force_update_meta = true;
                         } else {
-                            // Keep the existing curated display name
                             final_name = existing_display_name;
                         }
                     }
@@ -701,7 +680,6 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                     }
                 }
 
-                // Priority 2: Try Paperboy API /logos endpoint (high quality logos)
                 if (logo_url == null && host != null) {
                     try {
                         string api_url = "https://paperboybackend.onrender.com/logos?domain=" + host;
@@ -729,25 +707,19 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                     }
                 }
 
-                // Priority 3: Try Google Favicon Service (robust fallback)
                 if (logo_url == null && host != null) {
                     logo_url = get_favicon_url(host);
                 }
 
-                // Step 3: Add to database
                 var store = Paperboy.RssSourceStore.get_instance();
                 bool success = store.add_source(final_name, feed_url, null);
 
-                // Step 4: Save metadata and fetch logo
-                // Always fetch logo for newly added sources to ensure we have the best quality image
                 if (success && logo_url != null && host != null) {
                     SourceMetadata.update_index_and_fetch(host, final_name, logo_url, "https://" + host, window.session, feed_url);
                 }
 
-                // Step 5: Callback with result
                 GLib.Idle.add(() => {
-                    // A newly added source should show up as active without
-                    // requiring the user to also flip its switch in Settings.
+                    // Show as active without requiring the user to flip its switch in Settings.
                     if (success && window != null && window.prefs != null) {
                         window.prefs.set_preferred_source_enabled("custom:" + feed_url, true);
                         window.prefs.save_config();
@@ -768,8 +740,7 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
         });
     }
 
-    // Extract feed title from RSS/Atom XML
-    // Helper: recursively search an Xml.Node subtree for the first <title> element
+    // Recursively search an Xml.Node subtree for the first <title> element
     private string? find_first_title_in_xml(Xml.Node* node) {
         if (node == null) return null;
         for (Xml.Node* ch = node->children; ch != null; ch = ch->next) {
@@ -788,15 +759,12 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
 
     private string extract_feed_title_from_xml(string xml_content) {
         try {
-            // Prefer proper XML parsing rather than regex so we handle
-            // Atom titles with attributes (e.g. <title type="html">) and CDATA.
+            // Real XML parsing (not regex) to handle Atom titles with attributes and CDATA.
             Xml.Doc* doc = null;
             try {
-                // Use same safe parser options as rssParser
                 int parser_options = (int) (Xml.ParserOption.NONET | Xml.ParserOption.NOCDATA | Xml.ParserOption.NOBLANKS);
                 doc = Xml.Parser.read_memory(xml_content, (int) xml_content.length, null, null, parser_options);
             } catch (GLib.Error e) {
-                // Fallback: try to repair common issues by removing NULs
                 string cleaned = xml_content.replace("\0", "");
                 try { doc = Xml.Parser.read_memory(cleaned, (int) cleaned.length, null, null, (int)(Xml.ParserOption.NONET | Xml.ParserOption.NOCDATA | Xml.ParserOption.NOBLANKS)); } catch (GLib.Error ee) { doc = null; }
             }
@@ -806,7 +774,6 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                 if (root != null) {
                     string? found = find_first_title_in_xml(root);
                     if (found != null) {
-                        // Decode common HTML entities
                         found = found.replace("&amp;", "&");
                         found = found.replace("&lt;", "<");
                         found = found.replace("&gt;", ">");
@@ -827,9 +794,7 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
 
     // Discover and follow an RSS source from an article URL
     public void follow_rss_source(string article_url, string? source_metadata = null) {
-        // If the article appears to be from a built-in source, ignore follow
-        // requests and notify the user. This prevents adding built-in sources
-        // as custom RSS entries.
+        // Built-in sources can't be re-added as custom RSS entries.
         if (is_article_from_builtin(article_url)) {
             GLib.Idle.add(() => {
                 if (window != null) window.clear_persistent_toast();
@@ -839,22 +804,18 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
             return;
         }
 
-        // Call backend /rss/discover endpoint to discover RSS feed from article URL
         new Thread<void*>("rss-discover", () => {
             try {
-                // Extract the domain from the article URL to use as RSS discovery URL
                 string host = UrlUtils.extract_host_from_url(article_url);
                 if (host == null || host.length == 0) {
                     GLib.warning("Cannot follow source: invalid article URL");
                     return null;
                 }
 
-                // Parse source metadata from article if provided
                 string? article_display_name = null;
                 string? article_logo_url = null;
                 parse_source_metadata(source_metadata, out article_display_name, out article_logo_url);
 
-                // Call the backend /rss/discover endpoint
                 bool rss_discovery_succeeded = false;
                 try {
                     string backend_url = "https://paperboybackend.onrender.com/rss/discover";
@@ -864,15 +825,12 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                     headers.append("Content-Type", "application/json");
                     headers.append("User-Agent", "paperboy/0.5.1a");
 
-                    // Create JSON body with the article URL and max_pages parameter
                     string escaped_url = article_url.replace("\\", "\\\\").replace("\"", "\\\"");
                     string json_body = "{\"url\":\"" + escaped_url + "\",\"max_pages\":1}";
                     msg.set_request_body_from_bytes("application/json", new GLib.Bytes(json_body.data));
 
                     GLib.Bytes? response = window.session.send_and_read(msg, null);
                     var status = msg.get_status();
-                    
-                    // rss_discovery_succeeded is now defined outside this block
 
                     if (status == Soup.Status.OK && response != null) {
                         unowned uint8[] data = response.get_data();
@@ -881,7 +839,6 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                         } else {
                             string body = (string) data;
 
-                            // Parse the JSON response
                             try {
                                 var parser = new Json.Parser();
                                 parser.load_from_data(body, -1);
@@ -892,17 +849,14 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                                 } else {
                                     var root_obj = root.get_object();
 
-                                    // The response has a "feeds" array with discovered RSS feeds
                                     if (root_obj.has_member("feeds")) {
                                         var feeds_array = root_obj.get_array_member("feeds");
                                         if (feeds_array.get_length() > 0) {
-                                            // Take the first feed from the discovered feeds
                                             var first_feed = feeds_array.get_object_element(0);
                                             string feed_url = first_feed.get_string_member("url");
                                             string feed_title = first_feed.has_member("title") ? first_feed.get_string_member("title") : host;
                                             string? feed_description = first_feed.has_member("description") ? first_feed.get_string_member("description") : null;
 
-                                            // Extract metadata from API response (highest priority)
                                             string? api_source_name = null;
                                             string? api_logo_url = null;
                                             if (first_feed.has_member("source_name")) {
@@ -912,10 +866,7 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                                                 api_logo_url = first_feed.get_string_member("logo_url");
                                             }
 
-                                            // (Metadata parsing moved to top of function)
-
-                                            // Priority: API metadata (most reliable) > article metadata (what user saw) > feed title (cleaned)
-                                            // We prefer API metadata because it comes from the discovery service which has canonical info
+                                            // Priority: API metadata (canonical) > article metadata > feed title.
                                             string? metadata_display_name = api_source_name;
                                             string? metadata_logo_url = api_logo_url;
 
@@ -926,21 +877,17 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                                                 metadata_logo_url = article_logo_url;
                                             }
 
-                                            // Clean up feed_title if it's too long (likely a description, not a name)
+                                            // A title over 50 chars is likely a description, not a name.
                                             string cleaned_feed_title = feed_title;
                                             if (feed_title.length > 50) {
-                                                // Use host as fallback for overly long titles
                                                 cleaned_feed_title = host;
                                             }
 
-                                            // Use metadata if available, otherwise use cleaned feed info
                                             string final_title = (metadata_display_name != null && metadata_display_name.length > 0) ? metadata_display_name : cleaned_feed_title;
 
-                                            // Save to SQLite database with the proper display name
                                             var store = Paperboy.RssSourceStore.get_instance();
                                             bool success = store.add_source(final_title, feed_url, null);
 
-                                            // Save source metadata for the new source
                                             if (success) {
                                                 string save_display_name;
                                                 string save_logo_url;
@@ -957,18 +904,14 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
 
                                             if (success) {
                                                 GLib.Idle.add(() => {
-                                                    // A newly added source should show up as active without
-                                                    // requiring the user to also flip its switch in Settings.
+                                                    // Show as active without requiring the user to flip its switch in Settings.
                                                     if (window != null && window.prefs != null) {
                                                         window.prefs.set_preferred_source_enabled("custom:" + feed_url, true);
                                                         window.prefs.save_config();
                                                     }
-                                                    // The RssSourceStore's source_added signal (emitted
-                                                    // synchronously inside add_source() above) already
-                                                    // queued its own sidebar rebuild via an earlier Idle
-                                                    // callback, which can run before the enable step above
-                                                    // and filter this source right back out. Rebuild again
-                                                    // now that it's actually enabled.
+                                                    // add_source()'s source_added signal already queued a sidebar rebuild
+                                                    // that can run before the source is enabled and filter it back out;
+                                                    // rebuild again now that it's enabled.
                                                     if (window != null && window.sidebar_manager != null) {
                                                         window.sidebar_manager.rebuild_sidebar();
                                                     }
@@ -981,11 +924,9 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                                                     return false;
                                                 });
                                             }
-                                            
-                                            // Mark as successful so we don't fall through to html2rss
+
                                             rss_discovery_succeeded = true;
                                         } else {
-                                            // No feeds returned by the discovery API — will try html2rss fallback below
                                             GLib.warning("RSS discovery returned no feeds; will attempt local html2rss fallback");
                                         }
                                     }
@@ -1001,11 +942,9 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                     GLib.warning("RSS discovery API failed (exception): %s", e.message);
                 }
                 
-                // If RSS discovery didn't succeed, try local html2rss fallback
                 GLib.message("RSS Discovery status: succeeded=%s", rss_discovery_succeeded.to_string());
-                
+
                 if (!rss_discovery_succeeded) {
-                    // Safety check: ensure host is still valid before proceeding with fallback
                     if (host == null || host.length == 0) {
                         GLib.warning("Cannot attempt html2rss fallback: host is null or empty");
                         GLib.Idle.add(() => {
@@ -1015,7 +954,6 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                     } else {
                         GLib.message("Attempting local html2rss fallback for host: %s", host);
 
-                        // Update toast to inform user that feed generation is starting
                         GLib.Idle.add(() => {
                             if (window != null) window.clear_persistent_toast();
                             request_show_toast("Generating feed for this source...", true);
@@ -1025,21 +963,17 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                         string? script_path = null;
                         var binary_candidates = new ArrayList<string>();
 
-                        // If the AppRun or launcher set a libexec dir, prefer that first
+                        // Prefer the launcher-provided libexec dir (AppRun) if set
                         string? paperboy_libexec = GLib.Environment.get_variable("PAPERBOY_LIBEXECDIR");
                         if (paperboy_libexec != null && paperboy_libexec.length > 0) {
                             binary_candidates.add(GLib.Path.build_filename(paperboy_libexec, "paperboy", "html2rss"));
                             binary_candidates.add(GLib.Path.build_filename(paperboy_libexec, "html2rss"));
                         }
 
-                        // FHS-compliant: check libexecdir for internal binaries (per FHS 4.7)
+                        // FHS libexecdir (4.7), Flatpak/AppImage, then dev source tree locations
                         binary_candidates.add("/usr/libexec/paperboy/html2rss");
                         binary_candidates.add("/usr/local/libexec/paperboy/html2rss");
-
-                        // Flatpak/AppImage locations
                         binary_candidates.add("/app/libexec/paperboy/html2rss");
-
-                        // Development build locations (for running from source tree)
                         binary_candidates.add("tools/html2rss/target/release/html2rss");
                         binary_candidates.add("./tools/html2rss/target/release/html2rss");
                         binary_candidates.add("../tools/html2rss/target/release/html2rss");
@@ -1052,31 +986,24 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                             try {
                                 var f = GLib.File.new_for_path(c);
                                 if (f.query_exists(null)) {
-                                    // Ensure it's executable where possible
                                     try {
                                         var info = f.query_info("standard::access", 0, null);
                                         bool can_exec = false;
                                         if (info != null) {
                                             var perms = info.get_attribute_boolean("standard::access");
-                                            // fall back to assuming existence means executable on platforms where access attr may not be present
                                             can_exec = true;
                                         }
-                                    } catch (GLib.Error ee) {
-                                        // ignore permission check, treat existence as sufficient
-                                    }
+                                    } catch (GLib.Error ee) { }
                                     script_path = c;
                                     GLib.message("Found html2rss binary at: %s", c);
                                     break;
                                 }
-                            } catch (GLib.Error e) {
-                                // ignore and continue
-                            }
+                            } catch (GLib.Error e) { }
                         }
 
                         if (script_path != null) {
                             try {
-                                // Run the local html2rss binary using Gio/GLib Subprocess
-                                // Pass the URL as an argv element (avoids shell quoting issues)
+                                // argv element (not shell string) to avoid quoting issues
                                 string[] argv = { script_path, "--max-pages", "20", article_url };
                                 GLib.message("Running html2rss: %s %s %s %s", argv[0], argv[1], argv[2], argv[3]);
                                 
@@ -1085,14 +1012,10 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                                 int exit_status = 0;
 
                                 var proc = new GLib.Subprocess.newv(argv, GLib.SubprocessFlags.STDOUT_PIPE | GLib.SubprocessFlags.STDERR_PIPE);
-                                // Wait for process to finish and read pipes manually
                                 try {
                                     proc.wait_check(null);
-                                } catch (GLib.Error e) {
-                                    // wait_check failed; we'll still try to read any output
-                                }
+                                } catch (GLib.Error e) { }
 
-                                // Read stdout using a safe chunked loop (avoid read_bytes(-1))
                                 try {
                                     var stdout_stream = proc.get_stdout_pipe();
                                     string _out_acc = "";
@@ -1109,7 +1032,6 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                                     out_stdout = null;
                                 }
 
-                                // Read stderr using a safe chunked loop
                                 try {
                                     var stderr_stream = proc.get_stderr_pipe();
                                     string _err_acc = "";
@@ -1132,11 +1054,10 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
 
                                 if (out_stdout != null && out_stdout.strip().length > 0 && exit_status == 0) {
                                     string gen_feed = out_stdout.strip();
-                                    
-                                    // Clean up any trailing garbage (e.g. HTML links appended by html2rss)
+
+                                    // Strip trailing garbage (e.g. HTML links appended by html2rss)
                                     gen_feed = RssValidatorUtils.clean_rss_content(gen_feed);
 
-                                    // VALIDATE RSS before saving
                                     string? validation_error = null;
                                     bool is_valid = RssValidatorUtils.is_valid_rss(gen_feed, out validation_error);
                                     
@@ -1162,7 +1083,6 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                                     
                                     GLib.print("✓ Generated valid RSS feed with %d items\n", item_count);
 
-                                    // If the script printed raw RSS XML, save it to a local file
                                     if (gen_feed.has_prefix("<?xml") || gen_feed.has_prefix("<rss") || gen_feed.has_prefix("<feed") || gen_feed.has_prefix("<\n<?xml")) {
                                         try {
                                             string data_dir = GLib.Environment.get_user_data_dir();
@@ -1178,11 +1098,9 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                                             string file_path = GLib.Path.build_filename(gen_dir, filename);
 
                                             var f = GLib.File.new_for_path(file_path);
-                                            // Write the generated feed string directly to the file
-                                            // Write the generated feed via a replacement stream
                                             var out_stream = f.replace(null, false, GLib.FileCreateFlags.NONE, null);
                                             var writer = new DataOutputStream(out_stream);
-                                            // Ensure generated feed is safe for XML storage (strip illegal control chars)
+                                            // Strip illegal control chars so it's safe for XML storage
                                             string safe_feed = RssValidatorUtils.sanitize_for_xml(gen_feed);
                                             writer.put_string(safe_feed);
                                             writer.close(null);
@@ -1194,40 +1112,32 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                                     }
 
                                     var store = Paperboy.RssSourceStore.get_instance();
-                                    
-                                    // Check if we already have source_info for this host (from Front Page/Top Ten or RSS discovery)
-                                    // IMPORTANT: Use host as the key, not article_url, because that's how metadata is saved
+
+                                    // Keyed by host, not article_url, since that's how metadata is saved
                                     string feed_name = host;
                                     string? existing_display_name = null;
                                     string? existing_logo_url = null;
                                     string? existing_filename = null;
-                                    
-                                    // Try to get metadata by host first (this is where API metadata is stored)
+
                                     SourceMetadata.get_source_info_by_url(host, out existing_display_name, out existing_logo_url, out existing_filename);
-                                    
-                                    // Use the existing display name if available (from API/JSON-LD)
+
                                     if (existing_display_name != null && existing_display_name.length > 0) {
                                         feed_name = existing_display_name;
                                         GLib.print("✓ Using existing metadata: %s\n", feed_name);
                                     } else if (article_display_name != null && article_display_name.length > 0) {
-                                        // Use the passed article metadata (e.g. "AP News")
                                         feed_name = article_display_name;
                                         GLib.print("✓ Using article metadata: %s\n", feed_name);
                                     } else {
                                         GLib.print("⚠ No existing metadata found for %s, using host as name\n", host);
                                     }
-                                    
-                                    // Use add_source_with_original_url to store the original website URL
-                                    // This allows us to regenerate the feed later
+
+                                    // Store the original website URL so the feed can be regenerated later
                                     string original_website_url = "https://" + host;
                                     bool success = store.add_source_with_original_url(feed_name, gen_feed, original_website_url, null);
-                                    
-                                    // Save or update metadata for this source
-                                    // This ensures logos and proper names are set even for newly generated feeds
+
                                     if (success) {
                                         string? logo_url_to_save = existing_logo_url;
-                                        
-                                        // If we don't have a logo URL yet, use article logo or favicon fallback
+
                                         if (logo_url_to_save == null || logo_url_to_save.length == 0) {
                                             logo_url_to_save = (article_logo_url != null && article_logo_url.length > 0) ? article_logo_url : get_favicon_url(host);
                                         }
@@ -1235,25 +1145,20 @@ public delegate void RssFeedAddCallback(bool success, string feed_name);
                                         SourceMetadata.update_index_and_fetch(host, feed_name, logo_url_to_save, "https://" + host, window.session, gen_feed);
                                         GLib.print("✓ Saved metadata for %s\n", feed_name);
                                     }
-                                    
+
                                     if (success) {
                                         GLib.Idle.add(() => {
-                                            // A newly added source should show up as active without
-                                            // requiring the user to also flip its switch in Settings.
+                                            // Show as active without requiring the user to flip its switch in Settings.
                                             if (window != null && window.prefs != null) {
                                                 window.prefs.set_preferred_source_enabled("custom:" + gen_feed, true);
                                                 window.prefs.save_config();
                                             }
-                                            // The RssSourceStore's source_added signal (emitted
-                                            // synchronously inside add_source_with_original_url()
-                                            // above) already queued its own sidebar rebuild via an
-                                            // earlier Idle callback, which can run before the enable
-                                            // step above and filter this source right back out.
-                                            // Rebuild again now that it's actually enabled.
+                                            // add_source_with_original_url()'s source_added signal already queued a
+                                            // sidebar rebuild that can run before the source is enabled and filter it
+                                            // back out; rebuild again now that it's enabled.
                                             if (window != null && window.sidebar_manager != null) {
                                                 window.sidebar_manager.rebuild_sidebar();
                                             }
-                                            // Show followed message with article count
                                             request_show_toast("Following %s (%d articles)".printf(feed_name, item_count));
                                             return false;
                                         });

--- a/src/managers/viewStateManager.vala
+++ b/src/managers/viewStateManager.vala
@@ -24,13 +24,13 @@ namespace Managers {
     public class ViewStateManager : GLib.Object {
         private weak NewsWindow window;
 
-        // Article viewing state
         public Gee.HashSet<string> viewed_articles;
-        // Suppress marking an article viewed when a preview closes if the user
-        // explicitly requested to mark it unread from the preview pane.
+        // Skip the auto-mark-viewed-on-close when the user explicitly marked it unread from the preview pane.
         public Gee.HashSet<string> suppress_preview_mark;
         public Gee.HashMap<string, Gtk.Picture> url_to_picture;
-        public Gee.HashMap<string, Gtk.Widget> url_to_card;
+        // A URL can back more than one card (My Feed shows it in both its source row and category row),
+        // so lookups need every copy, not just the last one registered.
+        public Gee.HashMap<string, Gee.ArrayList<Gtk.Widget>> url_to_card;
         public Gee.HashMap<string, string> normalized_to_url;
         public string? last_previewed_url;
         public double last_scroll_value = -1.0;
@@ -43,7 +43,7 @@ namespace Managers {
             viewed_articles = new Gee.HashSet<string>();
             suppress_preview_mark = new Gee.HashSet<string>();
             url_to_picture = new Gee.HashMap<string, Gtk.Picture>();
-            url_to_card = new Gee.HashMap<string, Gtk.Widget>();
+            url_to_card = new Gee.HashMap<string, Gee.ArrayList<Gtk.Widget>>();
             normalized_to_url = new Gee.HashMap<string, string>();
         }
 
@@ -56,7 +56,12 @@ namespace Managers {
         }
 
         public void register_card_for_url(string normalized, Gtk.Widget card) {
-            url_to_card.set(normalized, card);
+            var list = url_to_card.get(normalized);
+            if (list == null) {
+                list = new Gee.ArrayList<Gtk.Widget>();
+                url_to_card.set(normalized, list);
+            }
+            if (!list.contains(card)) list.add(card);
         }
 
         public void unregister_card_for_url(string normalized) {
@@ -65,17 +70,18 @@ namespace Managers {
             url_to_card.remove(normalized);
         }
 
-        // ArticleCard's overlay is its root's direct first child, but
-        // HeroCard's overlay is nested inside a Grid (the text/picture
-        // split), so the same "first child is an Overlay" check that works
-        // for article cards silently finds nothing on a hero card. Check
-        // the hero shape's viewed-badge-slot data first, then fall back to
-        // the article-card shape.
-        // The "Viewed" badge lives in the title area's bottom-right slot,
-        // opposite the time caption (see ArticleCard/HeroCard's
-        // viewed_badge_slot, populated in build_viewed_badge) - not the
-        // image overlay, and not the top-right corner row the save ribbon
-        // occupies.
+        // For single-placement views (Saved, Front Page). My Feed callers should use get_cards_for_url() instead.
+        public Gtk.Widget? get_card_for_url(string normalized) {
+            var list = url_to_card.get(normalized);
+            return (list != null && list.size > 0) ? list.get(0) : null;
+        }
+
+        public Gee.ArrayList<Gtk.Widget>? get_cards_for_url(string normalized) {
+            return url_to_card.get(normalized);
+        }
+
+        // HeroCard nests its overlay inside a Grid, so it needs its own badge-slot lookup
+        // rather than ArticleCard's "first child is an Overlay" check.
         private Gtk.Widget? resolve_badge_container_for_card(Gtk.Widget card) {
             var hero_badge_slot = card.get_data<Gtk.Box>("hero-viewed-badge-slot");
             if (hero_badge_slot != null) return hero_badge_slot;
@@ -116,16 +122,16 @@ namespace Managers {
             if (viewed_articles == null) viewed_articles = new Gee.HashSet<string>();
             viewed_articles.add(n);
 
-            // Mark as viewed in article state store (persists to disk)
             if (window.article_state_store != null) {
                 window.article_state_store.mark_viewed(n);
             }
 
             Timeout.add(50, () => {
-                Gtk.Widget? card = url_to_card.get(n);
-                if (card != null) {
-                    var container = resolve_badge_container_for_card(card);
-                    if (container != null) {
+                var cards = url_to_card.get(n);
+                if (cards != null) {
+                    foreach (var card in cards) {
+                        var container = resolve_badge_container_for_card(card);
+                        if (container == null) continue;
                         bool already = false;
                         Gtk.Widget? c = container.get_first_child();
                         while (c != null) {
@@ -141,7 +147,6 @@ namespace Managers {
                 return false;
             });
 
-            // Emit signal for unread count updates
             article_viewed(n);
         }
 
@@ -172,8 +177,6 @@ namespace Managers {
             }
 
             if (url_copy != null) {
-                // If the preview requested suppression (user marked unread from the
-                // preview), honor that and do not mark viewed again.
                 string n = normalize_article_url(url_copy);
                 bool suppressed = (suppress_preview_mark != null && suppress_preview_mark.contains(n));
                 if (suppressed) {
@@ -212,10 +215,6 @@ namespace Managers {
             last_scroll_value = -1.0;
         }
 
-        /**
-        * Refresh viewed badges for all articles from a specific source
-        * Used after marking all as read/unread
-        */
         public void refresh_viewed_badges_for_source(string source_name) {
             if (window.article_state_store == null) return;
             
@@ -226,26 +225,20 @@ namespace Managers {
                 string normalized = normalize_article_url(url);
                 if (normalized == null || normalized.length == 0) continue;
                 
-                Gtk.Widget? card = null;
-                card = url_to_card.get(normalized);
-                if (card == null) continue;
-                
+                var cards = url_to_card.get(normalized);
+                if (cards == null) continue;
+
                 bool is_viewed = window.article_state_store.is_viewed(normalized);
 
-                var container = resolve_badge_container_for_card(card);
-                if (container != null) {
+                foreach (var card in cards) {
+                    var container = resolve_badge_container_for_card(card);
+                    if (container == null) continue;
                     remove_viewed_badges_from(container);
                     if (is_viewed) add_viewed_badge_to(container);
                 }
             }
         }
 
-        /**
-        * Suppress marking the given article as viewed when a preview closes.
-        * This is used when the user explicitly marks the article unread from
-        * the preview pane so the automatic "mark viewed on close" does not
-        * re-mark it.
-        */
         public void suppress_mark_on_preview_close(string url) {
             if (url == null) return;
             string n = normalize_article_url(url);
@@ -254,24 +247,21 @@ namespace Managers {
             suppress_preview_mark.add(n);
         }
 
-        /**
-        * Refresh the viewed badge for a single article URL (if a card exists).
-        */
         public void refresh_viewed_badge_for_url(string url) {
             if (url == null) return;
             string n = normalize_article_url(url);
             if (n == null || n.length == 0) return;
             if (window == null || window.article_state_store == null) return;
 
-            Gtk.Widget? card = null;
-            card = url_to_card.get(n); // return null if n is not in map
-            if (card == null) return;
+            var cards = url_to_card.get(n);
+            if (cards == null) return;
 
             bool is_viewed = false;
             is_viewed = window.article_state_store.is_viewed(n);
 
-            var container = resolve_badge_container_for_card(card);
-            if (container != null) {
+            foreach (var card in cards) {
+                var container = resolve_badge_container_for_card(card);
+                if (container == null) continue;
                 remove_viewed_badges_from(container);
                 if (is_viewed) {
                     add_viewed_badge_to(container);

--- a/src/processors/rssFeedProcessor.vala
+++ b/src/processors/rssFeedProcessor.vala
@@ -20,28 +20,23 @@ using Soup;
 using Xml;
 using Gee;
 
-// Removed xmlDisableEntityLoader binding: global state, not thread-safe, and unused.
-
-// Bind xmlFreeDoc so we can reliably free parser allocations for Xml.Doc*
 [CCode (cname = "xmlFreeDoc")]
 private static extern void xml_free_doc (Xml.Doc* doc);
 
 public class RssFeedProcessor {
-    // Maximum items to parse from local news RSS feeds (prevents memory bloat from large feeds)
-    // TODO: Make this configurable via preferences to allow power users to increase the limit
-    // Currently hardcoded to prevent UI slowdowns, but users may want more items for archival feeds
+    // TODO: make configurable via preferences
     private const int LOCAL_FEED_MAX_ITEMS = 30;
 
-    // Sanitize XML by removing invalid control characters and fixing encoding issues
     private static string sanitize_xml(string input) {
         var result = new StringBuilder();
         unowned string str = input;
 
-        for (int i = 0; i < input.length; ) {
+        // string.length is a full strlen() scan; cache it instead of rescanning every iteration (was O(n^2))
+        int input_length = input.length;
+        for (int i = 0; i < input_length; ) {
             unichar c;
             int prev_i = i;
             if (!input.get_next_char(ref i, out c)) {
-                // Invalid UTF-8 sequence - skip this byte
                 i = prev_i + 1;
                 continue;
             }
@@ -50,7 +45,7 @@ public class RssFeedProcessor {
                 continue;
             }
 
-            // Allow valid XML characters: Tab, LF, CR, printable chars
+            // valid XML chars: Tab, LF, CR, printable
             if (c == 0x09 || c == 0x0A || c == 0x0D || c >= 0x20) {
                 result.append_unichar(c);
             }
@@ -71,16 +66,10 @@ public class RssFeedProcessor {
         string? feed_url = null,
         string? cache_key_override = null
     ) {
-        // SECURITY FIX: Do NOT use NOENT (it substitutes entities and can enable XXE/Billion-laughs).
-        // Use NONET to forbid network access and disable entity substitution/DTD processing by
-        // avoiding NOENT and enabling safe options instead.
-        // NOCDATA: merge CDATA sections to text nodes
-        // NOBLANKS: remove ignorable whitespace
-        // RECOVER: try to recover from malformed XML where possible
+        // NONET avoids NOENT so entities/DTDs can't be used for XXE or billion-laughs attacks
         var parser_options = Xml.ParserOption.NONET | Xml.ParserOption.NOCDATA | Xml.ParserOption.NOBLANKS | Xml.ParserOption.RECOVER;
         Xml.Doc* doc = null;
         try {
-            // Sanitize the body to remove invalid control characters and bad UTF-8
             string sanitized_body = sanitize_xml(body);
             doc = Xml.Parser.read_memory(
                 sanitized_body,
@@ -95,7 +84,6 @@ public class RssFeedProcessor {
             }
 
             var items = new Gee.ArrayList<Gee.ArrayList<string?>>();
-            // Respect runtime feature flag to enable/disable BBC-specific extraction/normalization.
             bool bbc_enabled = false;
             try { string? env = GLib.Environment.get_variable("PAPERBOY_ENABLE_BBC_EXTRACT"); if (env == null) bbc_enabled = true; else bbc_enabled = env != "0"; } catch (GLib.Error e) { bbc_enabled = true; }
 
@@ -131,10 +119,7 @@ public class RssFeedProcessor {
                             string? thumb = null;
                             string? pub_date = null;
                             string? updated_date = null; // Atom fallback, only used if no pubDate/published found
-                            // The feed's own <description>/<summary> text, stripped to plain
-                            // text - stored on the resulting ArticleItem as a fallback snippet
-                            // for when live-fetching the article's own page fails (paywalls,
-                            // bot-blocking, transient errors). See ArticleSnippetService.
+                            // fallback snippet if live-fetching the article page later fails
                             string? desc_text = null;
                             int thumb_width = -1;
                             bool thumb_is_thumbnail_tag = false;
@@ -176,10 +161,7 @@ public class RssFeedProcessor {
                                         }
                                     }
                                 } else if (c->name == "thumbnail" && c->ns != null && c->ns->prefix == "media") {
-                                    // Skip media:thumbnail if we already have media:content (higher quality).
-                                    // Some feeds (e.g. ABC News) emit several media:thumbnail entries per
-                                    // item at different resolutions, in no guaranteed order, so keep the
-                                    // widest one seen instead of just the first.
+                                    // some feeds emit multiple media:thumbnail entries at different resolutions; keep the widest
                                     if (thumb == null || thumb_is_thumbnail_tag) {
                                         Xml.Attr* a2 = c->properties;
                                         string? cand_url = null;
@@ -376,10 +358,7 @@ public class RssFeedProcessor {
                                             }
                                         }
                                     } else if (c->name == "thumbnail" && c->ns != null && c->ns->prefix == "media") {
-                                        // Skip media:thumbnail if we already have media:content (higher quality).
-                                        // Some feeds (e.g. ABC News) emit several media:thumbnail entries per
-                                        // item at different resolutions, in no guaranteed order, so keep the
-                                        // widest one seen instead of just the first.
+                                        // some feeds emit multiple media:thumbnail entries at different resolutions; keep the widest
                                         if (thumb == null || thumb_is_thumbnail_tag) {
                                             Xml.Attr* a2 = c->properties;
                                             string? cand_url = null;
@@ -499,7 +478,6 @@ public class RssFeedProcessor {
                 }
             }
 
-            // Update UI on main thread
             Idle.add(() => {
                 if (current_search_query.length > 0) {
                     set_label(@"Search Results: \"$(current_search_query)\" in $(category_name) — $(source_name)");
@@ -513,7 +491,6 @@ public class RssFeedProcessor {
                     string url = row[1] ?? "";
                     string? pub_date = row.size > 3 ? row[3] : null;
 
-                    // Filter by search query if provided (case-insensitive substring match)
                     if (current_search_query.length > 0) {
                         string query_lower = current_search_query.down();
                         string title_lower = title.down();
@@ -524,13 +501,12 @@ public class RssFeedProcessor {
                         }
                     }
 
-                    // Cache article for offline access and faster feed switching
-                    // Use cache_key_override (original_url) for generated feeds to ensure cache persistence across regenerations
+                    // cache_key_override lets generated feeds keep cache continuity across regenerations
                     if (feed_url != null && feed_url.length > 0) {
                         var cache = Paperboy.RssArticleCache.get_instance();
                         string cache_key = (cache_key_override != null && cache_key_override.length > 0) ? cache_key_override : feed_url;
 
-                        // Extract source metadata from source_name (format: "Name||logo_url##category::cat")
+                        // source_name format: "Name||logo_url##category::cat"
                         string? extracted_source_name = null;
                         string? extracted_logo_url = null;
                         string? extracted_category_id = null;
@@ -538,7 +514,6 @@ public class RssFeedProcessor {
                         if (source_name != null && source_name.length > 0) {
                             extracted_source_name = source_name;
 
-                            // Remove category suffix first
                             int cat_idx = source_name.index_of("##category::");
                             if (cat_idx >= 0) {
                                 extracted_source_name = source_name.substring(0, cat_idx);
@@ -547,7 +522,6 @@ public class RssFeedProcessor {
                                 }
                             }
 
-                            // Extract logo URL
                             int pipe_idx = extracted_source_name.index_of("||");
                             if (pipe_idx >= 0) {
                                 if (extracted_source_name.length > pipe_idx + 2) {
@@ -567,8 +541,7 @@ public class RssFeedProcessor {
                 return false;
             });
 
-            // Update favicon asynchronously in background thread to avoid SQLite lock contention
-            // Don't block the main thread or article display for favicon updates
+            // update favicon off the main thread to avoid SQLite lock contention
             if (category_id == "myfeed" && favicon_url != null && favicon_url.length > 0) {
                 string captured_source_name = source_name;
                 string captured_favicon = favicon_url;
@@ -589,7 +562,6 @@ public class RssFeedProcessor {
                 });
             }
 
-            // Background: for BBC links, try to fetch higher-resolution images
             if (bbc_enabled) {
                 AddItemFunc safe_add = (title, url, thumbnail, cid, sname, published) => {
                     Idle.add(() => { add_item(title, url, thumbnail, cid, sname, published); return false; });
@@ -638,47 +610,33 @@ public class RssFeedProcessor {
         string? cache_key_override = null
     ) {
         new Thread<void*>("fetch-rss", () => {
-            // Keep references to the provided callbacks for the lifetime
-            // of this worker thread. Vala's generated closure refcounting
-            // sometimes frees caller-side temporary delegates when the
-            // caller's scope returns; holding explicit local references
-            // in the thread ensures the delegates remain alive until the
-            // thread completes and avoids use-after-free when the
-            // callbacks are invoked later on the main loop.
+            // hold local refs so the closures survive after the caller's scope returns
             var _set_label_ref = set_label;
             var _clear_items_ref = clear_items;
             var _add_item_ref = add_item;
             try {
 
-                // Basic validation: ensure the URL is a non-empty, sane string
-                // (avoid passing malformed URLs into HttpClient which may return
-                // errors or a null body that propagate back into FetchContext).
                 string trimmed = url.strip();
                 if (trimmed.length == 0) {
                     warning("RSS fetch called with empty URL for source '%s'", source_name);
                     try { set_label("Error loading feed — invalid (empty) URL"); } catch (GLib.Error e) { }
                     return null;
                 }
-                // Disallow obvious invalid schemes or whitespace in the URL.
                 if (trimmed.contains(" ") || !(trimmed.has_prefix("http://") || trimmed.has_prefix("https://") || trimmed.has_prefix("file://"))) {
                     warning("RSS fetch called with malformed/unsupported URL for source '%s': %s", source_name, url);
                     try { set_label("Error loading feed — invalid URL"); } catch (GLib.Error e) { }
                     return null;
                 }
-                // Support local file:// feeds by reading the file directly
                 if (url.has_prefix("file://")) {
                     try {
                         string path = url.substring(7);
                         var f = GLib.File.new_for_path(path);
                         if (!f.query_exists(null)) {
-                            // File doesn't exist - trigger background regeneration
+                            // regeneration is handled by FeedUpdateManager, not here
                             warning("Local RSS file not found, will need regeneration: %s", path);
                             try { set_label("Generating feed... (this may take 30-40 seconds)"); } catch (GLib.Error e) { }
-                            // TODO: Trigger async regeneration here
-                            // For now, just show an error since regeneration is handled by FeedUpdateManager
                             return null;
                         }
-                        // Use FileUtils.get_contents to safely read the whole file into memory
                         string body = "";
                         bool ok = GLib.FileUtils.get_contents(path, out body);
                         if (!ok || body.length == 0) {
@@ -695,25 +653,15 @@ public class RssFeedProcessor {
                 }
 
                 var client = Paperboy.HttpClientUtils.get_default();
-                // Reddit's RSS/Atom feeds are very aggressive about
-                // rejecting/rate-limiting the generic default User-Agent
-                // (confirmed: it gets blocked almost immediately, while a
-                // real-browser-looking one is treated normally) - so use
-                // browser-style headers specifically for reddit.com feed
-                // URLs, same as RedditFetcher does for the built-in Reddit
-                // category. Left as the plain default for every other feed
-                // to avoid touching behavior for sources that already work.
+                // reddit rate-limits the default User-Agent, so use browser-style headers for it (like RedditFetcher does)
                 Paperboy.HttpClientUtils.RequestOptions? fetch_options = null;
                 if (url.down().contains("reddit.com")) {
                     fetch_options = new Paperboy.HttpClientUtils.RequestOptions().with_browser_headers();
                 }
                 var http_response = client.fetch_sync(url, fetch_options);
 
-                // Defensive handling for network-level failures (status_code == 0)
                 if (http_response.status_code == 0) {
-                    // Prefer the error message provided by the HttpClient (GLib.Error.message)
                     if (http_response.error_message != null && http_response.error_message.length > 0) {
-                        // Surface DNS resolution failures more clearly
                         if (http_response.error_message.contains("Name or service not known") ||
                             http_response.error_message.contains("Temporary failure in name resolution") ||
                             http_response.error_message.contains("No address associated with hostname")) {
@@ -746,7 +694,6 @@ public class RssFeedProcessor {
                 warning("RSS fetch error: %s", e.message);
                 try { set_label("Error loading feed"); } catch (GLib.Error _) { }
             }
-            // Drop our explicit references so they can be freed.
             _set_label_ref = null;
             _clear_items_ref = null;
             _add_item_ref = null;

--- a/src/services/articleStateStore.vala
+++ b/src/services/articleStateStore.vala
@@ -19,11 +19,8 @@ using GLib;
 using Gee;
 using Sqlite;
 
-/*
- * ArticleStateStore: manages only simple per-article metadata (viewed/favorite/timestamps)
- * No pixbufs, textures, widgets, or image URLs. Minimal, thread-safe helpers.
- */
-
+// Manages per-article metadata (viewed/favorite/timestamps) only - no pixbufs, textures,
+// widgets, or image URLs.
 public class ArticleStateStore : GLib.Object {
     // Emitted when saved articles have been loaded from disk
     public signal void saved_articles_loaded();
@@ -65,11 +62,8 @@ public class ArticleStateStore : GLib.Object {
         public string? thumbnail;
         public string? source;
         public int64 saved_timestamp;
-        // The original article's own published date (as given by its feed/
-        // API at the time it was saved), used to show the same "X ago" time
-        // caption on saved cards as everywhere else in the app. Null for
-        // articles saved before this field existed, or where the source
-        // never gave a published date to begin with.
+        // The original published date from the article's feed/API, so saved cards can show the
+        // same "X ago" caption as everywhere else. Null for articles saved before this field existed.
         public string? published;
 
         public SavedArticle(string url, string title, string? thumbnail, string? source, string? published = null) {
@@ -97,23 +91,14 @@ public class ArticleStateStore : GLib.Object {
         visited_sources = new Gee.HashSet<string>();
         saved_articles = new Gee.HashMap<string, SavedArticle>();
 
-        // Initialize SQLite database for saved articles
         init_saved_articles_db();
-
-        // Migrate saved articles from JSON to database if needed
         migrate_saved_articles_from_json();
 
-        // Load persisted article tracking on startup to show cached badge counts immediately
-        // The deferred background metadata fetch (at 10s) will update with fresh counts
-        // This provides instant visual feedback while fresh data loads in background
+        // Show cached badge counts immediately; the deferred background metadata fetch updates them later.
         load_article_tracking();
-
-        // Load saved articles from database
         load_saved_articles_from_db();
 
-        // Ensure saved articles also participate in category-based tracking so
-        // the "saved" category has a stable backing set for unread counts and
-        // badge logic on startup.
+        // Saved articles need their own category tracking entry for unread-count/badge logic on startup.
         var current_saved = get_saved_articles();
         foreach (var article in current_saved) {
             if (article != null && article.url != null && article.url.length > 0) {
@@ -121,13 +106,11 @@ public class ArticleStateStore : GLib.Object {
                     string norm_url = UrlUtils.normalize_article_url(article.url);
                     if (norm_url == null || norm_url.length == 0) norm_url = article.url.strip();
                     register_article(norm_url, "saved", article.source);
-                } catch (GLib.Error e) {
-                    // Best-effort; skip problematic entries
-                }
+                } catch (GLib.Error e) { }
             }
         }
 
-        // preload small metadata set: scan .meta files for viewed flag
+        // Preload viewed flags from .meta files
         try {
             var meta_dir = File.new_for_path(cache_dir_path);
             FileEnumerator? en = null;
@@ -273,8 +256,7 @@ public class ArticleStateStore : GLib.Object {
 
     // Register an article with its category and source for unread tracking
     public void register_article(string url, string? category_id, string? source_name) {
-        // Normalize the URL OUTSIDE the lock to reduce lock contention
-        // when many threads are calling this simultaneously
+        // Normalize outside the lock to reduce contention under concurrent callers
         string norm_url = "";
         norm_url = UrlUtils.normalize_article_url(url);
 
@@ -313,8 +295,7 @@ public class ArticleStateStore : GLib.Object {
         article_tracking_lock.lock();
         visited_categories.add(category_id);
         article_tracking_lock.unlock();
-        // Defer persist to disk to avoid blocking UI on every click
-        // Save will happen on next article registration or app shutdown
+        // Persisted on next article registration or shutdown, not here, to avoid blocking the UI thread.
     }
 
     // Check if a category has been visited
@@ -339,8 +320,7 @@ public class ArticleStateStore : GLib.Object {
         article_tracking_lock.lock();
         visited_sources.add(source_name);
         article_tracking_lock.unlock();
-        // Defer persist to disk to avoid blocking UI on every click
-        // Save will happen on next article registration or app shutdown
+        // Persisted on next article registration or shutdown, not here, to avoid blocking the UI thread.
     }
 
     // Check if a source has been visited
@@ -397,8 +377,7 @@ public class ArticleStateStore : GLib.Object {
             var articles = category_articles.get(category_id);
             total = articles.size;
 
-            // PERFORMANCE: Only check viewed status from in-memory cache
-            // Don't do disk I/O during count calculation - that's too slow
+            // In-memory cache only - no disk I/O during count calculation
             meta_lock.lock();
             try {
                 foreach (string url in articles) {
@@ -417,57 +396,25 @@ public class ArticleStateStore : GLib.Object {
         return total - viewed;
     }
 
-    // Get unread count for "myfeed" category, filtering by enabled sources only
-    public int get_unread_count_for_myfeed(NewsPreferences prefs) {
+    // Get unread count for "myfeed" category, restricted to what actually got
+    // a card built in the current My Feed view (displayed_urls - see
+    // ArticleManager.get_myfeed_displayed_urls()). category_articles["myfeed"]
+    // holds every article ever registered for the category, which is far
+    // more than ArticleManager.MYFEED_ROW_CARD_CAP ever lets onto the page,
+    // so counting that directly badly overcounts. Falls back to 0 if My Feed
+    // hasn't been built yet this session (displayed_urls null/empty) rather
+    // than showing that inflated total.
+    public int get_unread_count_for_myfeed(Gee.HashSet<string>? displayed_urls) {
+        if (displayed_urls == null || displayed_urls.size == 0) return 0;
+
         int total = 0;
         int viewed = 0;
 
         article_tracking_lock.lock();
         try {
-            if (!category_articles.has_key("myfeed")) {
-                return 0;
-            }
-
-            var articles = category_articles.get("myfeed");
-
-            // PERFORMANCE: Build the set of URLs that belong to an enabled
-            // source in one pass over category_articles/source_articles,
-            // instead of rescanning both maps for every myfeed article
-            // (which was O(articles * (categories + sources))).
-            var enabled_urls = new Gee.HashSet<string>();
-
-            foreach (var entry in category_articles.entries) {
-                string category_id = entry.key;
-                if (!category_id.has_prefix("rssfeed:")) continue;
-
-                string rss_url = category_id.substring("rssfeed:".length);
-                string check_key = "custom:" + rss_url;
-                if (!prefs.preferred_source_enabled(check_key)) continue;
-
-                foreach (string url in entry.value) {
-                    enabled_urls.add(url);
-                }
-            }
-
-            // Built-in sources only count if "custom only" mode is disabled
-            if (!prefs.myfeed_custom_only) {
-                foreach (var source_entry in source_articles.entries) {
-                    string source_name = source_entry.key;
-                    if (source_name.has_prefix("rssfeed:")) continue;
-                    if (!prefs.preferred_source_enabled(source_name)) continue;
-
-                    foreach (string url in source_entry.value) {
-                        enabled_urls.add(url);
-                    }
-                }
-            }
-
-            // PERFORMANCE: Only check viewed status from in-memory cache
             meta_lock.lock();
             try {
-                foreach (string url in articles) {
-                    if (!enabled_urls.contains(url)) continue;
-
+                foreach (string url in displayed_urls) {
                     total++;
                     string meta_path = meta_path_for(url);
                     if (viewed_meta_paths.contains(meta_path)) {
@@ -498,8 +445,6 @@ public class ArticleStateStore : GLib.Object {
             var articles = source_articles.get(source_name);
             total = articles.size;
 
-            // PERFORMANCE: Only check viewed status from in-memory cache
-            // Don't do disk I/O during count calculation - that's too slow
             meta_lock.lock();
             try {
                 foreach (string url in articles) {
@@ -525,7 +470,6 @@ public class ArticleStateStore : GLib.Object {
             if (!source_articles.has_key(source_name)) {
                 return null;
             }
-            // Return a copy to avoid concurrent modification
             var copy = new Gee.HashSet<string>();
             var articles = source_articles.get(source_name);
             foreach (string url in articles) {
@@ -587,21 +531,19 @@ public class ArticleStateStore : GLib.Object {
         return out;
     }
 
-    // Clear all article tracking (useful when refreshing/reloading)
-    // Preserves the "saved" category since saved articles are persistent user data
+    // Clear all article tracking (useful when refreshing/reloading), preserving "saved"
+    // since saved articles are persistent user data.
     public void clear_article_tracking() {
         article_tracking_lock.lock();
         try {
-            // Preserve saved articles tracking
             Gee.HashSet<string>? saved_set = null;
             if (category_articles.has_key("saved")) {
                 saved_set = category_articles.get("saved");
             }
-            
+
             category_articles.clear();
             source_articles.clear();
-            
-            // Restore saved articles tracking
+
             if (saved_set != null) {
                 category_articles.set("saved", saved_set);
             }
@@ -797,20 +739,15 @@ public class ArticleStateStore : GLib.Object {
         }
     }
 
-    // Saved articles management
     public void save_article(string url, string title, string? thumbnail = null, string? source = null, string? published = null) {
-        // Persist saved metadata to database and ensure the article is registered under the
-        // "saved" category for unread-count tracking.
         saved_lock.lock();
         var article = new SavedArticle(url, title, thumbnail, source, published);
         saved_articles.set(url, article);
         saved_lock.unlock();
 
-        // Persist to database
         save_article_to_db(url, title, thumbnail, source, published, GLib.get_real_time() / 1000000);
 
-        // Register the saved article for category-based unread tracking. Do
-        // this outside of the saved_lock to avoid lock ordering issues.
+        // Register outside saved_lock to avoid lock ordering issues.
         string norm = UrlUtils.normalize_article_url(url);
         if (norm == null || norm.length == 0) norm = url.strip();
         register_article(norm, "saved", source);
@@ -818,18 +755,13 @@ public class ArticleStateStore : GLib.Object {
     }
 
     public void unsave_article(string url) {
-        // Remove from saved list and from the "saved" category tracking so
-        // unread counts update correctly.
         saved_lock.lock();
         try {
-            // Attempt direct remove first
             if (saved_articles.has_key(url)) {
                 saved_articles.unset(url);
             } else {
-                // Fallback: remove any entry whose canonical normalized URL
-                // matches the requested URL's normalized form. This covers
-                // situations where saved entries were stored with a slightly
-                // different URL form (scheme missing, trailing slash, etc.).
+                // Fall back to normalized-URL match in case the entry was stored in a
+                // slightly different form (missing scheme, trailing slash, etc).
                 string norm = url;
                 try { norm = UrlUtils.normalize_article_url(url); } catch (GLib.Error e) { norm = url.strip(); }
                 var keys_to_remove = new Gee.ArrayList<string>();
@@ -849,10 +781,8 @@ public class ArticleStateStore : GLib.Object {
             saved_lock.unlock();
         }
 
-        // Remove from database
         remove_article_from_db(url);
 
-        // Also remove from category tracking
         try {
             string norm = UrlUtils.normalize_article_url(url);
             if (norm == null || norm.length == 0) norm = url.strip();
@@ -873,7 +803,6 @@ public class ArticleStateStore : GLib.Object {
         saved_lock.lock();
         try {
             if (saved_articles.has_key(url)) return true;
-            // Check normalized match
             string norm = url;
             try { norm = UrlUtils.normalize_article_url(url); } catch (GLib.Error e) { norm = url.strip(); }
             foreach (var k in saved_articles.keys) {
@@ -896,7 +825,6 @@ public class ArticleStateStore : GLib.Object {
         foreach (var article in saved_articles.values) {
             list.add(article);
         }
-        // Sort by saved timestamp, newest first
         list.sort((a, b) => {
             return (int)(b.saved_timestamp - a.saved_timestamp);
         });
@@ -908,7 +836,6 @@ public class ArticleStateStore : GLib.Object {
         saved_lock.lock();
         try {
             if (saved_articles.has_key(url)) return saved_articles.get(url);
-            // Try normalized lookup
             string norm = url;
             try { norm = UrlUtils.normalize_article_url(url); } catch (GLib.Error e) { norm = url.strip(); }
             foreach (var k in saved_articles.keys) {
@@ -942,8 +869,7 @@ public class ArticleStateStore : GLib.Object {
                 if (norm == null || norm.length == 0) norm = article.url.strip();
                 if (!is_viewed(norm)) cnt++;
             } catch (GLib.Error e) {
-                // Best-effort: treat as unread if we cannot normalize/check
-                cnt++;
+                cnt++; // treat as unread if normalization fails
             }
         }
         saved_lock.unlock();
@@ -965,7 +891,6 @@ public class ArticleStateStore : GLib.Object {
                 return;
             }
 
-            // Create table if it doesn't exist
             string create_table = """
                 CREATE TABLE IF NOT EXISTS saved_articles (
                     url TEXT PRIMARY KEY,
@@ -982,17 +907,13 @@ public class ArticleStateStore : GLib.Object {
                 stderr.printf("Failed to create saved articles table: %s\n", saved_db.errmsg());
             }
 
-            // Existing databases predate the "published" column above (added
-            // so saved cards can show the same "X ago" caption as every
-            // other card) - add it if it's not there yet. Ignore the error
-            // when the column already exists.
+            // Older databases predate the "published" column; add it, ignoring the error if it exists.
             saved_db.exec("ALTER TABLE saved_articles ADD COLUMN published TEXT;", null, null);
         } finally {
             saved_db_lock.unlock();
         }
     }
 
-    // Save article to database
     private void save_article_to_db(string url, string title, string? thumbnail, string? source, string? published, int64 timestamp) {
         saved_db_lock.lock();
         if (saved_db == null) {
@@ -1027,7 +948,6 @@ public class ArticleStateStore : GLib.Object {
         saved_db_lock.unlock();
     }
 
-    // Remove article from database
     private void remove_article_from_db(string url) {
         saved_db_lock.lock();
         if (saved_db == null) {
@@ -1054,7 +974,6 @@ public class ArticleStateStore : GLib.Object {
         saved_db_lock.unlock();
     }
 
-    // Load saved articles from database
     private void load_saved_articles_from_db() {
         saved_db_lock.lock();
         try {
@@ -1087,8 +1006,7 @@ public class ArticleStateStore : GLib.Object {
                 saved_lock.unlock();
             }
 
-            // Register loaded saved articles into category tracking so the
-            // sidebar can immediately show the correct "Saved" badge count.
+            // So the sidebar can immediately show the correct "Saved" badge count.
             try {
                 foreach (var article in saved_articles.values) {
                     try {
@@ -1099,21 +1017,19 @@ public class ArticleStateStore : GLib.Object {
                 }
             } catch (GLib.Error e) { }
 
-            // Notify listeners (UI) that saved articles are now available
             try { saved_articles_loaded(); } catch (GLib.Error e) { }
         } finally {
             saved_db_lock.unlock();
         }
     }
 
-    // Migrate saved articles from JSON file to database (one-time migration)
+    // One-time migration of saved articles from the old JSON file to SQLite.
     private void migrate_saved_articles_from_json() {
         string saved_file = Path.build_filename(cache_dir_path, "saved_articles.json");
         if (!FileUtils.test(saved_file, FileTest.EXISTS)) {
-            return; // No JSON file to migrate
+            return;
         }
 
-        // Check if database already has articles (already migrated)
         saved_db_lock.lock();
         if (saved_db == null) {
             saved_db_lock.unlock();
@@ -1126,14 +1042,12 @@ public class ArticleStateStore : GLib.Object {
         if (rc == Sqlite.OK && stmt.step() == Sqlite.ROW) {
             int count = stmt.column_int(0);
             if (count > 0) {
-                // Database already has articles, skip migration
                 saved_db_lock.unlock();
                 return;
             }
         }
         saved_db_lock.unlock();
 
-        // Parse JSON file and migrate to database
         try {
             var parser = new Json.Parser();
             parser.load_from_file(saved_file);
@@ -1160,10 +1074,7 @@ public class ArticleStateStore : GLib.Object {
                             timestamp = article_obj.get_int_member("saved_timestamp");
                         }
 
-                        // Save to database. The old JSON format never
-                        // recorded the article's published date, so this
-                        // migrated entry won't have a time caption until
-                        // re-saved - there's no original value to recover.
+                        // Old JSON format never recorded published date; nothing to migrate for it.
                         save_article_to_db(url, title, thumbnail, source, null, timestamp);
                         migrated_count++;
                     }
@@ -1171,7 +1082,6 @@ public class ArticleStateStore : GLib.Object {
 
                 stderr.printf("Migrated %d saved articles from JSON to SQLite database\n", migrated_count);
 
-                // Rename JSON file to .bak to avoid re-migration
                 string backup_file = saved_file + ".bak";
                 try {
                     FileUtils.rename(saved_file, backup_file);

--- a/src/services/imageCache.vala
+++ b/src/services/imageCache.vala
@@ -30,11 +30,8 @@ public class ImageCache : GLib.Object {
     private LruCache<string, Gdk.Texture> texture_cache;
     private static ImageCache? global_instance = null;
 
-    // Hard ceiling on total decoded pixbuf memory this cache will hold.
-    // Entry-count capacity alone doesn't protect against this: a handful of
-    // oversized hero/carousel decodes can each be tens of megabytes, so a
-    // count-based cap of a couple hundred entries still allows multi-GB
-    // growth. This bounds actual memory instead.
+    // Byte cap, not just entry count: a few oversized hero/carousel decodes
+    // could otherwise blow past a count-based limit.
     private const int64 MAX_PIXBUF_CACHE_BYTES = 200 * 1024 * 1024;
 
     public ImageCache(int capacity = 256) {
@@ -44,42 +41,27 @@ public class ImageCache : GLib.Object {
         pixbuf_cache.set_byte_budget(MAX_PIXBUF_CACHE_BYTES, (key, pixbuf) => {
             return (int64) pixbuf.get_byte_length();
         });
-        // Same budget for cached textures: get_texture() below reuses a
-        // cached Gdk.Texture instead of re-uploading on every call, so this
-        // needs its own bound just like the pixbuf cache does.
         texture_cache.set_byte_budget(MAX_PIXBUF_CACHE_BYTES, (key, tex) => {
             return (int64) tex.get_width() * tex.get_height() * 4;
         });
 
-        // IMPORTANT DEPENDENCY: This implementation relies on Gee.HashMap's automatic
-        // reference counting behavior for GObject values. When Gee stores a GObject
-        // (like Gdk.Pixbuf or Gdk.Texture), it automatically calls g_object_ref() on
-        // insert and g_object_unref() on remove/clear. This means:
-        // 1. We do NOT manually ref/unref pixbufs when storing them
-        // 2. The container manages the lifecycle automatically
-        // 3. If Gee's behavior changes or we switch container libraries, this could break
-        // 4. Tests should verify this behavior doesn't regress
+        // Gee ref/unrefs GObject values automatically on insert/remove, so
+        // we don't manually ref/unref pixbufs or textures here.
 
-        // A pixbuf falling out of the cache - whether overwritten (see set()
-        // below) or LRU-evicted - must take its cached texture with it.
-        // get_texture() reuses whatever's in texture_cache, so a stale
-        // entry surviving its pixbuf's eviction would keep serving a
-        // texture whose content no longer matches what's nominally cached
-        // under that key.
+        // A pixbuf's cached texture must be dropped along with it, or
+        // get_texture() would keep serving stale content under that key.
         pixbuf_cache.set_eviction_callback((k, v) => {
             try { texture_cache.remove(k); } catch (GLib.Error e) { }
         });
 
-        // Textures are automatically freed when unreferenced
         texture_cache.set_eviction_callback((k, v) => {
             if (AppDebugger.debug_enabled()) {
             }
         });
     }
 
-    // Global singleton accessor so legacy static code can delegate to the
-    // application's ImageCache instance. The NewsWindow constructor will set
-    // the global via `set_global` when it creates its per-window cache.
+    // Legacy static code delegates to this; NewsWindow sets the real
+    // instance via set_global() when it creates its per-window cache.
     public static ImageCache get_global() {
         if (global_instance == null) global_instance = new ImageCache(256);
         return global_instance;

--- a/src/services/locationLookupService.vala
+++ b/src/services/locationLookupService.vala
@@ -49,13 +49,37 @@ public class LocationLookupService : GLib.Object {
         });
     }
 
+    // How many forward-search candidates to request from Nominatim so we
+    // have something to filter by country (see resolve_text below). Note:
+    // geocode-glib's set_bounded()/set_search_area() do NOT reliably
+    // restrict geocode-glib's default backend for a free-text query (the
+    // resulting "viewbox" parameter is silently dropped), so this class
+    // doesn't rely on them.
+    private const uint CANDIDATE_COUNT = 10;
+
     private static async ResolvedLocation resolve_text(string query) {
         try {
             var forward = new Geocode.Forward.for_string(query);
-            forward.set_answer_count(1);
+            forward.set_answer_count(CANDIDATE_COUNT);
             var results = yield forward.search_async();
             if (results == null || results.length() == 0) return ResolvedLocation.empty();
-            return resolve_place(results.nth_data(0));
+
+            // A bare ZIP/postal code is genuinely ambiguous worldwide (e.g.
+            // US ZIP "10001" also matches real postal codes in Ukraine,
+            // Iraq, Taiwan, Peru, ...), and Nominatim's top-ranked global
+            // match is frequently not the US one. Since Paperboy is a
+            // US-focused app, prefer the first result actually in the US
+            // over whatever ranks highest globally.
+            unowned Geocode.Place chosen = results.nth_data(0);
+            foreach (unowned Geocode.Place place in results) {
+                var country_code = place.get_country_code();
+                if (country_code != null && country_code.ascii_down() == "us") {
+                    chosen = place;
+                    break;
+                }
+            }
+
+            return resolve_place(chosen, double.NAN, double.NAN, query);
         } catch (GLib.Error e) {
             return ResolvedLocation.empty();
         }
@@ -81,7 +105,14 @@ public class LocationLookupService : GLib.Object {
             var geocode_loc = new Geocode.Location(loc.latitude, loc.longitude);
             var reverse = new Geocode.Reverse.for_location(geocode_loc);
             var place = yield reverse.resolve_async();
-            return resolve_place(place);
+            // Use GeoClue's own coordinates for the nearest-major-city
+            // lookup rather than place.get_location(): geocode-glib's
+            // reverse resolution has been observed to come back with a
+            // Place whose location has a garbage latitude (e.g. 0.0)
+            // even though the place's name/town/state are resolved
+            // correctly, which would otherwise send MajorCitiesUtils.nearest()
+            // wildly off course.
+            return resolve_place(place, loc.latitude, loc.longitude);
         } catch (GLib.Error e) {
             return ResolvedLocation.empty();
         }
@@ -96,34 +127,89 @@ public class LocationLookupService : GLib.Object {
         }
     }
 
-    private static ResolvedLocation resolve_place(Geocode.Place? place) {
-        string display = format_place(place);
+    // `known_lat`/`known_lon` let a caller that already has an
+    // authoritative coordinate (e.g. GeoClue's GPS fix) use it for the
+    // nearest-major-city lookup instead of place.get_location(), which
+    // for some resolved places is unreliable (see detect_current_location).
+    // Pass NAN for both when no such coordinate is available. `query_text`
+    // is the user's original typed search text (null when there wasn't
+    // one, e.g. GPS detection); see format_place for how it's used.
+    private static ResolvedLocation resolve_place(Geocode.Place? place, double known_lat = double.NAN, double known_lon = double.NAN, string? query_text = null) {
+        string display = format_place(place, query_text);
         if (display.length == 0) return ResolvedLocation.empty();
 
         string news_query = display;
-        if (place != null) {
-            var loc = place.get_location();
-            if (loc != null) {
-                double distance_km;
-                string nearest = MajorCitiesUtils.nearest(loc.latitude, loc.longitude, out distance_km);
-                if (nearest.length > 0) {
-                    news_query = nearest;
+        double lat = known_lat;
+        double lon = known_lon;
+        if (lat.is_nan() || lon.is_nan()) {
+            if (place != null) {
+                var loc = place.get_location();
+                if (loc != null) {
+                    lat = loc.latitude;
+                    lon = loc.longitude;
                 }
+            }
+        }
+
+        if (!lat.is_nan() && !lon.is_nan()) {
+            double distance_km;
+            string nearest = MajorCitiesUtils.nearest(lat, lon, out distance_km);
+            if (nearest.length > 0) {
+                news_query = nearest;
             }
         }
 
         return ResolvedLocation() { display = display, news_query = news_query };
     }
 
-    private static string format_place(Geocode.Place? place) {
+    // `query_text` is the raw text the user typed (e.g. "Chicago"), used
+    // as a fallback display city when the resolved place has no usable
+    // town/city detail; pass null when there was no typed query (GPS
+    // detection).
+    private static string format_place(Geocode.Place? place, string? query_text = null) {
         if (place == null) return "";
 
+        // Reject matches too coarse to be a meaningful "City, State"
+        // result (e.g. a bare country or continent) rather than falling
+        // back to place.get_name(), which for these is just the country
+        // name and would otherwise duplicate against get_state() as
+        // "United States, United States".
+        switch (place.get_place_type()) {
+        case Geocode.PlaceType.COUNTRY:
+        case Geocode.PlaceType.CONTINENT:
+        case Geocode.PlaceType.STATE:
+        case Geocode.PlaceType.HISTORICAL_STATE:
+        case Geocode.PlaceType.OCEAN:
+        case Geocode.PlaceType.SEA:
+        case Geocode.PlaceType.TIME_ZONE:
+            return "";
+        default:
+            break;
+        }
+
         string city = place.get_town();
-        if (city == null || city.length == 0) city = place.get_name();
         if (city == null) city = "";
 
+        // When there's no town detail, prefer the user's own typed text
+        // (normally the real city name) over place.get_name(): for a
+        // match that only resolved down to country-level detail,
+        // get_name() is unreliable — it can come back as just the
+        // country's own name, or even doubled as literally "United
+        // States, United States" — which would otherwise print twice
+        // once concatenated with the state below.
+        if (city.length == 0) {
+            if (query_text != null && query_text.length > 0) {
+                city = query_text;
+            } else {
+                string name = place.get_name() ?? "";
+                string country = place.get_country() ?? "";
+                city = (country.length > 0 && name.contains(country)) ? "" : name;
+            }
+        }
+        if (city.length == 0) return "";
+
         string state = place.get_state();
-        if (state != null && state.length > 0) {
+        if (state != null && state.length > 0 && state != city) {
             return city + ", " + state;
         }
         return city;

--- a/src/services/lruCache.vala
+++ b/src/services/lruCache.vala
@@ -30,20 +30,15 @@ public class LruCache<K, V> : GLib.Object {
     // Protect internal state from concurrent access across threads
     private GLib.Mutex mutex;
     private int capacity;
-    // Optional eviction callback invoked when entries are removed due to
-    // capacity limits or explicit clear/remove. Callers can use this to
-    // release resources or log heavy textures. Kept optional to remain
-    // backwards-compatible.
+    // Called when an entry is removed via capacity/byte-budget eviction or
+    // explicit clear/remove.
     public delegate void EvictionCallback<K, V>(K key, V value);
     private EvictionCallback<K, V>? on_evict;
 
-    // Optional byte-weighed eviction. When a weigher is installed (see
-    // set_byte_budget), eviction is driven by the summed byte size of the
-    // stored values instead of the raw entry count - a handful of huge
-    // decoded images can otherwise sit well under a count-based `capacity`
-    // while consuming gigabytes of memory. The entry-count `capacity` is
-    // still enforced as a secondary hard cap in this mode so a flood of
-    // tiny entries can't grow the order/map bookkeeping unboundedly.
+    // When a weigher is installed (see set_byte_budget), eviction is driven
+    // by summed byte size instead of entry count. `capacity` still applies
+    // as a secondary hard cap so a flood of tiny entries can't grow
+    // bookkeeping unboundedly.
     public delegate int64 SizeFunc<K, V>(K key, V value);
     private SizeFunc<K, V>? size_func;
     private int64 max_bytes = -1;
@@ -53,26 +48,18 @@ public class LruCache<K, V> : GLib.Object {
         GLib.Object();
         if (capacity <= 0) capacity = 128;
         this.capacity = capacity;
-        // Use default Gee containers. Gee will handle GObject
-        // duplication/destroy semantics for stored values (it will
-        // ref on insert and unref on remove/clear). ImageCache is
-        // adjusted to avoid double-unref and therefore we rely on
-        // the container to manage the pixbuf lifecycle.
         map = new Gee.HashMap<K, V>();
         order = new Gee.ArrayList<K>();
         mutex = new GLib.Mutex();
     }
 
-    // Set an optional eviction callback. Passing null clears the callback.
     public void set_eviction_callback(EvictionCallback<K, V>? cb) {
         on_evict = cb;
     }
 
-    // Switch this cache into byte-budget mode: `weigher` computes the
-    // approximate byte size of a stored value, and `set()` will evict the
-    // least-recently-used entries until the running total is back under
-    // `bytes`. Pass a non-positive `bytes` to disable and fall back to
-    // plain entry-count eviction.
+    // `weigher` computes a stored value's approximate byte size; set() then
+    // evicts LRU entries until under `bytes`. Non-positive `bytes` disables
+    // byte-budget mode.
     public void set_byte_budget(int64 bytes, owned SizeFunc<K, V> weigher) {
         mutex.lock();
         try {

--- a/src/services/prefs.vala
+++ b/src/services/prefs.vala
@@ -181,7 +181,17 @@ public class NewsPreferences : GLib.Object {
         owned get {
             var list = new Gee.ArrayList<string>();
             string[] arr = settings.get_strv("personalized-categories");
-            foreach (var s in arr) list.add(s);
+            // Defensive: an earlier iteration of My Feed's custom-feed
+            // opt-in briefly stored "customfeed:<url>" entries in this same
+            // list before that was moved to its own dedicated
+            // myfeed_included_feeds preference. Any such entries left over
+            // from that on a real install aren't a real topic category and
+            // would otherwise build a permanently-empty, oddly-labeled row
+            // in My Feed - filter them out here so stale data can't
+            // resurface that bug.
+            foreach (var s in arr) {
+                if (!s.has_prefix("customfeed:")) list.add(s);
+            }
             return list;
         }
         set {
@@ -196,6 +206,50 @@ public class NewsPreferences : GLib.Object {
                 settings.set_strv("personalized-categories", arr);
             }
         }
+    }
+
+    // URLs of custom RSS feeds included in My Feed. Deliberately separate
+    // from preferred_sources' "custom:<url>" entries: that flag controls
+    // whether the feed exists/shows in the sidebar at all (see
+    // SidebarManager.get_sidebar_sections()), independent of whether it's
+    // merged into My Feed - this is that second, independent opt-in.
+    public Gee.ArrayList<string> myfeed_included_feeds {
+        owned get {
+            var list = new Gee.ArrayList<string>();
+            string[] arr = settings.get_strv("myfeed-included-feeds");
+            foreach (var s in arr) list.add(s);
+            return list;
+        }
+        set {
+            if (value == null) {
+                settings.set_strv("myfeed-included-feeds", new string[0]);
+            } else {
+                string[] arr = new string[value.size];
+                for (int i = 0; i < value.size; i++) arr[i] = value.get(i);
+                settings.set_strv("myfeed-included-feeds", arr);
+            }
+        }
+    }
+
+    public bool myfeed_feed_enabled(string url) {
+        foreach (var u in myfeed_included_feeds) if (u == url) return true;
+        return false;
+    }
+
+    public void set_myfeed_feed_enabled(string url, bool enabled) {
+        var current_list = myfeed_included_feeds;
+        var updated_list = new Gee.ArrayList<string>();
+        foreach (var u in current_list) updated_list.add(u);
+
+        if (enabled) {
+            if (!updated_list.contains(url)) updated_list.add(url);
+        } else {
+            var to_remove = new Gee.ArrayList<string>();
+            foreach (var u in updated_list) if (u == url) to_remove.add(u);
+            foreach (var r in to_remove) updated_list.remove(r);
+        }
+
+        myfeed_included_feeds = updated_list;
     }
 
     // Master on/off switch for the Sports category's score-card sections,
@@ -271,24 +325,11 @@ public class NewsPreferences : GLib.Object {
                 foreach (var r in to_remove) preferred_sources.remove(r);
             }
         }
-        // Keep the single-source `news_source` value (which drives regular
-        // category browsing, e.g. World News/Technology/etc.) in sync with
-        // the "Built-in News Sources" switches in Preferences.
-        //
-        // This used to require the WHOLE `preferred_sources` list - built-in
-        // switches AND every followed custom RSS feed combined - to shrink
-        // to exactly one entry before updating news_source. That's the list
-        // "My Feed" personalization also uses, so anyone with even one
-        // custom feed followed (nearly everyone, in practice) could never
-        // trigger it: switching a built-in source on in Preferences would
-        // silently do nothing to what regular category pages show, with no
-        // indication anything was wrong.
-        //
-        // Toggling a built-in source's switch ON is an unambiguous signal
-        // on its own - it doesn't need the rest of the list's state to
-        // confirm intent - so sync directly off `id`/`enabled` here instead,
-        // completely independent of how many custom feeds happen to be
-        // enabled.
+        // Keep the single-source `news_source` value (drives regular category
+        // browsing) in sync with the "Built-in News Sources" switches.
+        // Sync directly off `id`/`enabled` rather than requiring
+        // `preferred_sources` to shrink to one entry - that list also holds
+        // followed custom RSS feeds, so it rarely has just one entry.
         if (enabled) {
             switch (id) {
                 case "guardian": news_source = NewsSource.GUARDIAN; break;

--- a/src/services/unreadFetchService.vala
+++ b/src/services/unreadFetchService.vala
@@ -17,19 +17,17 @@
 
 public class UnreadFetchService {
 
-    // Weak reference to window for safe lifecycle management.
-    // DO NOT use FetchContext here - it would cancel the main content fetch!
+    // Weak so this doesn't keep the window alive. Do NOT use FetchContext here - it would
+    // cancel the main content fetch.
     private static weak NewsWindow? _unread_window = null;
 
-    // Separate session with shorter timeout for background metadata fetches
-    // This ensures background fetches fail fast and don't block the UI
+    // Shorter timeout than the main session so background fetches fail fast without blocking the UI.
     private static Soup.Session? _metadata_session = null;
 
-    // Fetch queue and throttling
-    // NOTE: Static Gee collections must be initialized lazily in Vala
+    // Static Gee collections need lazy init in Vala (inline initializers don't run).
     private static Gee.Queue<FetchTask>? _fetch_queue = null;
     private static int _active_fetches = 0;
-    private const int MAX_CONCURRENT_FETCHES = 3;  // Limit concurrent fetches to prevent resource contention
+    private const int MAX_CONCURRENT_FETCHES = 3;
 
     // Task types for the fetch queue
     private enum TaskType {
@@ -76,7 +74,7 @@ public class UnreadFetchService {
     private static Soup.Session get_metadata_session() {
         if (_metadata_session == null) {
             _metadata_session = new Soup.Session() {
-                timeout = 5  // Shorter timeout for background fetches (5 seconds)
+                timeout = 5
             };
         }
         return _metadata_session;
@@ -93,38 +91,31 @@ public class UnreadFetchService {
         var win = _unread_window;
         if (win == null) return;
 
-        // Safely access article_state_store through local variable
         var store = win.article_state_store;
         if (store == null) return;
 
         string normalized = win.normalize_article_url(url);
         store.register_article(normalized, category_id, source_name);
 
-        // Also register under myfeed if this article should appear there
         var prefs = win.prefs;
         if (prefs == null) return;
 
-        // RSS sources: check if the custom RSS source is enabled
+        // RSS sources: needs both the "enabled" switch and the separate My Feed opt-in.
         if (category_id != null && category_id.has_prefix("rssfeed:")) {
             string rss_url = category_id.substring("rssfeed:".length);
-            if (prefs.preferred_source_enabled("custom:" + rss_url)) {
+            if (prefs.preferred_source_enabled("custom:" + rss_url) && prefs.myfeed_feed_enabled(rss_url)) {
                 store.register_article(normalized, "myfeed", "rssfeed:" + rss_url);
             }
         }
-        // Built-in sources: check if source is enabled AND category is in personalized categories
-        // AND that "custom only" mode is disabled
+        // Built-in sources: needs source enabled, category personalized, and custom-only mode off.
         else if (source_name != null && category_id != null && prefs.personalized_feed_enabled && !prefs.myfeed_custom_only) {
-            // Check if this is a personalized category for myfeed
             var personalized_cats = prefs.personalized_categories;
             if (personalized_cats != null && personalized_cats.contains(category_id)) {
-                // Normalize the source display name to canonical ID
                 string? source_id = SourceManager.normalize_source_display_name_to_id(source_name);
 
                 if (source_id != null) {
-                    // Check if the source is enabled
                     bool is_enabled = prefs.preferred_source_enabled(source_id);
                     if (is_enabled) {
-                        // Register with normalized source ID for consistent filtering
                         store.register_article(normalized, "myfeed", source_id);
                     }
                 }
@@ -145,7 +136,6 @@ public class UnreadFetchService {
 
             _active_fetches++;
 
-            // Execute the fetch based on task type
             var win = _unread_window;
             if (win == null) {
                 _active_fetches--;
@@ -154,10 +144,9 @@ public class UnreadFetchService {
 
             switch (task.type) {
                 case TaskType.CATEGORY:
-                    // Always clear category before background fetch to prevent accumulation
-                    // Skip only if this is the category the user is currently viewing (main fetch handles it)
-                    // NOTE: We clear on EVERY fetch, not just once per run, because the backend
-                    // may return different articles each time and we need fresh counts
+                    // Clear before every fetch (not just once) since the backend can return different
+                    // articles each time. Skip only the category the user is currently viewing - the
+                    // main fetch already handles that one.
                     if (win != null && win.article_state_store != null && task.category != null) {
                         bool should_clear = (win.prefs == null || win.prefs.category != task.category);
 
@@ -177,7 +166,6 @@ public class UnreadFetchService {
                             global_metadata_add(title, url, thumb, cat_id, src_name);
                         }
                     );
-                    // Decrement counter after a short delay to allow fetch to start
                     GLib.Timeout.add(100, () => {
                         _active_fetches--;
                         process_fetch_queue();
@@ -234,40 +222,29 @@ public class UnreadFetchService {
         }
     }
 
-    // Fetch article metadata for all *regular* categories and RSS sources in background
-    // to populate unread counts. Special categories like myfeed, local_news, and saved
-    // are handled separately and must not be treated as normal fetchable categories here.
+    // Fetches regular categories and RSS sources in the background to populate unread counts.
+    // Special categories (myfeed, local_news, saved) are handled separately.
     public static void fetch_all_category_metadata_for_counts(NewsWindow win) {
         if (win == null) return;
 
-        // Store weak reference to window for callbacks.
-        // DO NOT use FetchContext.begin_new() here - it would cancel the main content fetch!
+        // Do NOT use FetchContext.begin_new() - it would cancel the main content fetch.
         _unread_window = win;
 
-        // Clear any existing queue
         get_fetch_queue().clear();
         _active_fetches = 0;
 
-        // DO NOT clear article tracking here - this is a background metadata fetch
-        // that should supplement the counts, not replace them. Clearing happens
-        // in the main fetch (fetchNewsController) when the user navigates to a category.
-        // Clearing here causes race conditions where:
-        // 1. User views frontpage (main fetch adds 40 articles)
-        // 2. Background fetch clears all tracking (including frontpage)
-        // 3. Background fetch re-adds frontpage articles
-        // 4. Result: duplicate counting or lost articles
+        // Don't clear article tracking here - this only supplements counts. The main fetch
+        // (fetchNewsController) clears on category navigation; clearing here too races with it
+        // and can drop or double-count articles.
 
-        // Get all enabled built-in sources for My Feed
-        // This ensures we fetch metadata from ALL enabled sources, not just the effective_news_source
         var source_mgr = win.source_manager;
         var enabled_sources = (source_mgr != null) ? source_mgr.get_enabled_source_enums() : new Gee.ArrayList<NewsSource>();
 
-        // If no built-in sources are explicitly enabled, fall back to effective_news_source
         if (enabled_sources.size == 0) {
             enabled_sources.add(win.effective_news_source());
         }
 
-        // Priority categories - fetch these first to ensure they load even if RSS feeds timeout
+        // Fetch these first so they load even if RSS feeds time out
         string[] priority_categories = {"frontpage", "topten"};
         foreach (var source in enabled_sources) {
             foreach (string cat in priority_categories) {

--- a/src/ui/appWindow.vala
+++ b/src/ui/appWindow.vala
@@ -592,10 +592,11 @@ public class NewsWindow : Adw.ApplicationWindow {
         });
     }
 
-    // My Feed overlay: wire the "Select news sources" button to open preferences
+    // My Feed overlay: wire the "Configure personalization" button to open
+    // preferences directly on the Personalization page.
     if (loading_state.personalized_message_action != null) {
         loading_state.personalized_message_action.clicked.connect(() => {
-            PrefsDialog.show_preferences_dialog(this);
+            PrefsDialog.show_preferences_dialog(this, true);
         });
     }
 

--- a/src/ui/components/categorySection.vala
+++ b/src/ui/components/categorySection.vala
@@ -61,7 +61,12 @@ public class CategorySection : GLib.Object {
     // bordered/rounded panel so the row's cards read as one grouped unit -
     // used for the Sports score sections; article-row sections leave it off
     // and keep their plain flush layout.
-    public CategorySection(NewsWindow? window, string display_name, string query_category, bool center_nav_on_full_row = false, bool card_container = false, string? logo_url = null, bool show_live_pill = false) {
+    // nav_target_id: sidebar id to jump to (see SidebarManager.
+    // handle_item_activation) via the row's trailing "..." button, shown
+    // once the row is scrolled to its end. Null hides the button - used for
+    // rows with no matching sidebar page, like My Feed's built-in-source
+    // rows.
+    public CategorySection(NewsWindow? window, string display_name, string query_category, bool center_nav_on_full_row = false, bool card_container = false, string? logo_url = null, bool show_live_pill = false, string? logo_file_path = null, string? nav_target_id = null) {
         this.window = window;
         this.query_category = query_category;
 
@@ -75,14 +80,17 @@ public class CategorySection : GLib.Object {
         label.add_css_class("caption");
         label.set_markup("<span size='18000'><b>%s</b></span>".printf(display_name.up()));
 
-        // Only the Sports score sections pass a logo_url and/or show_live_pill -
-        // every other CategorySection caller keeps the plain text-only header.
-        if ((logo_url != null && logo_url.length > 0) || show_live_pill) {
+        // Only the Sports score sections and My Feed's source/custom-feed
+        // rows pass a logo (file path, URL, and/or show_live_pill) - every
+        // other CategorySection caller keeps the plain text-only header.
+        bool has_logo_file = logo_file_path != null && logo_file_path.length > 0;
+        bool has_logo_url = logo_url != null && logo_url.length > 0;
+        if (has_logo_file || has_logo_url || show_live_pill) {
             var header = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 8);
             header.set_halign(Gtk.Align.START);
             header.set_valign(Gtk.Align.CENTER);
 
-            if (logo_url != null && logo_url.length > 0) {
+            if (has_logo_file || has_logo_url) {
                 // Circular logo baked into the pixel data via PixbufUtils, same
                 // technique the source-badge/source-row favicons already use
                 // elsewhere in the app - CSS-only circular clipping (a plain
@@ -92,7 +100,11 @@ public class CategorySection : GLib.Object {
                 // scope.
                 var logo = PixbufUtils.make_circular_logo_placeholder(30);
                 header.append(logo);
-                PixbufUtils.load_circular_logo_async(logo, logo_url, 30);
+                if (has_logo_file) {
+                    PixbufUtils.load_circular_logo_from_file(logo, logo_file_path, 30);
+                } else {
+                    PixbufUtils.load_circular_logo_async(logo, logo_url, 30);
+                }
             }
 
             if (show_live_pill) {
@@ -145,14 +157,21 @@ public class CategorySection : GLib.Object {
         overlay.set_child(scroller);
         overlay.set_hexpand(true);
 
+        // Own box (small, fixed spacing) for the row plus its trailing "..."
+        // button, kept separate from wrapper's own 20px header-to-content
+        // spacing so the button sits close under the row instead of
+        // inheriting that same wide gap.
+        var content_box = new Gtk.Box(Gtk.Orientation.VERTICAL, 6);
+        content_box.append(overlay);
+
         if (card_container) {
             var container = new Gtk.Box(Gtk.Orientation.VERTICAL, 0);
             container.add_css_class("section-card-container");
             container.set_hexpand(true);
-            container.append(overlay);
+            container.append(content_box);
             wrapper.append(container);
         } else {
-            wrapper.append(overlay);
+            wrapper.append(content_box);
         }
 
         Gtk.Adjustment result_adj;
@@ -160,6 +179,17 @@ public class CategorySection : GLib.Object {
         add_nav_buttons(overlay, scroller, row, window, query_category, load_more_state, out result_adj, out result_right_button, center_nav_on_full_row);
         scroll_adjustment = result_adj;
         right_nav_button = result_right_button;
+
+        if (nav_target_id != null) {
+            add_more_button(content_box, window, nav_target_id, display_name);
+        } else {
+            // category_sections_container's spacing is sized for a section
+            // ending in this "..." button; a section with no button (ends
+            // in a full card row instead) wants a bit more breathing room
+            // before the next divider. A plain positive margin, unlike a
+            // negative one, doesn't fight GTK's layout pass.
+            wrapper.set_margin_bottom(8);
+        }
     }
 
     /**
@@ -293,6 +323,26 @@ public class CategorySection : GLib.Object {
         adj.value_changed.connect(() => update_scroll_fades(adj, left_fade, right_fade));
         adj.changed.connect(() => update_scroll_fades(adj, left_fade, right_fade));
         update_scroll_fades(adj, left_fade, right_fade);
+    }
+
+    // Plain "Go to <title>" button under the row (not overlaid on the
+    // cards), fixed in place - jumps to nav_target_id's full page via the
+    // sidebar. Names the destination directly rather than "See all", which
+    // reads as "load more into this row" - the row's own nav arrows already
+    // do that. Static for the same reason as add_nav_buttons: it hangs a
+    // closure off a signal owned by `wrapper`.
+    private static void add_more_button(Gtk.Box wrapper, NewsWindow? win, string nav_target_id, string title) {
+        var more_button = new Gtk.Button.with_label("Go to " + title + " →");
+        more_button.add_css_class("flat");
+        more_button.add_css_class("section-more-button");
+        more_button.set_halign(Gtk.Align.END);
+        wrapper.append(more_button);
+
+        more_button.clicked.connect(() => {
+            if (win != null && win.sidebar_manager != null) {
+                win.sidebar_manager.handle_item_activation(nav_target_id, title);
+            }
+        });
     }
 
     /**

--- a/src/ui/contentView.vala
+++ b/src/ui/contentView.vala
@@ -248,7 +248,7 @@ public class ContentView : GLib.Object {
         // Category-grouped sections (Front Page only): one labeled,
         // horizontally-scrollable row of cards per category, built and
         // shown/hidden by LayoutManager instead of the flat columns_row.
-        category_sections_container = new Gtk.Box(Gtk.Orientation.VERTICAL, 32);
+        category_sections_container = new Gtk.Box(Gtk.Orientation.VERTICAL, 16);
         category_sections_container.set_halign(Gtk.Align.FILL);
         category_sections_container.set_hexpand(true);
         category_sections_container.set_visible(false);
@@ -316,7 +316,7 @@ public class ContentView : GLib.Object {
         personalized_message_sub_label.set_visible(false);
         inner_center.append(personalized_message_sub_label);
 
-        personalized_message_action = new Gtk.Button.with_label("Select news sources");
+        personalized_message_action = new Gtk.Button.with_label("Personalize My Feed");
         personalized_message_action.set_halign(Gtk.Align.CENTER);
         personalized_message_action.set_valign(Gtk.Align.CENTER);
         personalized_message_action.set_margin_top(8);

--- a/src/ui/controllers/fetchNewsController.vala
+++ b/src/ui/controllers/fetchNewsController.vala
@@ -17,21 +17,22 @@
 
 public class FetchNewsController {
 
-    // Buffering for multi-source fetches (see FetchContext.is_multi_source):
-    // instead of handing each article straight to ArticleManager as its
-    // source's network request completes - which orders the view by
-    // "whichever source answered first" rather than by how recent the
-    // articles actually are - we hold items in a short-lived per-fetch
-    // buffer, keyed by FetchContext.seq, and flush them newest-first once
-    // things go quiet (or a max wait elapses, so one slow source can't stall
-    // the whole view indefinitely). Any articles arriving after a seq has
-    // already flushed stream straight through unbuffered, same as before.
+    // Multi-source fetches buffer incoming articles per FetchContext.seq and flush
+    // newest-first once things go quiet (or MULTI_SOURCE_MAX_WAIT_MS elapses), instead
+    // of ordering by whichever source responds first. Late arrivals after a flush stream
+    // straight through unbuffered.
     private const uint MULTI_SOURCE_DEBOUNCE_MS = 350;
     private const uint MULTI_SOURCE_MAX_WAIT_MS = 2500;
-    // NOTE: Static Gee collections must be initialized lazily in Vala - a
-    // field initializer here never runs since FetchNewsController is never
-    // instantiated (only called through static methods), which left these
-    // null and crashed the first Gee call against them.
+    // Per-Idle-callback time budget in flush_multi_source_buffer(), in microseconds.
+    // Budgeting by wall-clock time (not item count) keeps each callback about one
+    // frame's worth of work even though per-item build cost varies a lot.
+    private const int64 DISPATCH_BATCH_BUDGET_US = 8000;
+    // Hard cap on articles buffered/sorted/dispatched per flush. My Feed's source x
+    // category fan-out can return 1000+ raw candidates with no display cap to fall
+    // back on, so this is the only thing bounding per-flush cost.
+    private const int MULTI_SOURCE_BUFFER_CAP = 400;
+    // static Gee fields need lazy init in Vala - a field initializer here never runs
+    // since this class is never instantiated
     private static Gee.HashMap<uint, Gee.ArrayList<ArticleItem>>? _multi_source_buffers = null;
     private static Gee.HashMap<uint, uint>? _multi_source_timeouts = null;
     private static Gee.HashMap<uint, int64?>? _multi_source_started_at = null;
@@ -54,10 +55,7 @@ public class FetchNewsController {
         return _multi_source_flushed;
     }
 
-    // Shared tail of global_add_item(): track this article for adaptive
-    // layout, then hand it to ArticleManager. Split out so the buffered
-    // (multi-source) and direct (single-source) paths can both funnel
-    // through the same logic.
+    // shared tail of global_add_item(): both buffered and direct paths funnel through here
     private static void dispatch_item(NewsWindow w, FetchContext cur, string title, string url, string? thumbnail, string category_id, string? source_name, string? published, string? snippet) {
         var cat_mgr = w.category_manager;
         var layout_mgr = w.layout_manager;
@@ -88,7 +86,9 @@ public class FetchNewsController {
         }
         var item = new ArticleItem(title, url, thumbnail, category_id, source_name, published);
         item.snippet = snippet;
-        multi_source_buffers().get(seq).add(item);
+        var buffered = multi_source_buffers().get(seq);
+        buffered.add(item);
+        if (buffered.size > MULTI_SOURCE_BUFFER_CAP) evict_oldest_buffered_item(buffered);
 
         if (multi_source_timeouts().has_key(seq)) {
             GLib.Source.remove(multi_source_timeouts().get(seq));
@@ -107,9 +107,30 @@ public class FetchNewsController {
         multi_source_timeouts().set(seq, tid);
     }
 
-    // Sort the buffered batch newest-first (articles with no recognizable
-    // published date sort last, keeping their arrival order among
-    // themselves) and hand each one to dispatch_item() in that order.
+    // Evict the oldest item from whichever pool (myfeed vs. built-in) currently holds
+    // more than its fair share, so a large custom-feed pool can't push built-in
+    // articles out of the buffer entirely (or vice versa).
+    private static void evict_oldest_buffered_item(Gee.ArrayList<ArticleItem> items) {
+        int myfeed_count = 0;
+        foreach (var it in items) if (it.category_id == "myfeed") myfeed_count++;
+        bool evict_myfeed = myfeed_count > (items.size - myfeed_count);
+
+        int oldest_index = -1;
+        GLib.DateTime? oldest_dt = null;
+        for (int i = 0; i < items.size; i++) {
+            if ((items.get(i).category_id == "myfeed") != evict_myfeed) continue;
+            var dt = DateUtils.parse_published_datetime(items.get(i).published);
+            bool this_is_older = (oldest_index == -1) || (dt == null) ? (oldest_index == -1 || oldest_dt != null) : (oldest_dt != null && dt.compare(oldest_dt) < 0);
+            if (this_is_older) {
+                oldest_index = i;
+                oldest_dt = dt;
+            }
+        }
+        if (oldest_index == -1) return;
+        items.remove_at(oldest_index);
+    }
+
+    // sort newest-first (undated articles sort last, keeping arrival order among themselves)
     private static void flush_multi_source_buffer(uint seq) {
         if (!multi_source_buffers().has_key(seq)) return;
         var items = multi_source_buffers().get(seq);
@@ -133,17 +154,27 @@ public class FetchNewsController {
             return db.compare(da);
         });
 
-        foreach (var item in items) {
-            if (w.prefs != null && cur.expected_category != null && w.prefs.category != cur.expected_category) break;
-            dispatch_item(w, cur, item.title, item.url, item.thumbnail_url, item.category_id, item.source_name, item.published, item.snippet);
-        }
+        // dispatch in small batches via Idle so building many cards doesn't block the main loop
+        int index = 0;
+        Idle.add(() => {
+            if (!FetchContext.is_current(seq)) return false;
+            var cur2 = FetchContext.current_context();
+            if (cur2 == null || !cur2.is_valid() || cur2.seq != seq) return false;
+            var w2 = cur2.window;
+            if (w2 == null) return false;
+            if (w2.prefs != null && cur2.expected_category != null && w2.prefs.category != cur2.expected_category) return false;
+
+            int64 batch_start = GLib.get_monotonic_time();
+            while (index < items.size && (GLib.get_monotonic_time() - batch_start) < DISPATCH_BATCH_BUDGET_US) {
+                var item = items.get(index);
+                dispatch_item(w2, cur2, item.title, item.url, item.thumbnail_url, item.category_id, item.source_name, item.published, item.snippet);
+                index++;
+            }
+            return index < items.size;
+        });
     }
 
-    // Non-capturing label forwarder used for passing a stable callback
-    // into worker fetchers. It does not close over any stack state so
-    // it is safe to pass across thread boundaries. It uses
-    // Global label forwarder: looks up the current FetchContext and the
-    // active window and update the header accordingly.
+    // non-capturing so it's safe to pass across thread boundaries into worker fetchers
     public static void global_forward_label(string? text) {
         Idle.add(() => {
             var ctx = FetchContext.current_context();
@@ -151,15 +182,12 @@ public class FetchNewsController {
             var win = ctx.window;
             if (win == null) return false;
 
-            // Detect errors in the label text and immediately show error message
             if (text != null) {
                 string lower = text.down();
                 if (lower.index_of("error") >= 0 || lower.index_of("failed") >= 0) {
                     if (win.loading_state != null) win.loading_state.network_failure_detected = true;
-                    // Immediately show error message and hide spinner to prevent UI dead-end
                     win.hide_loading_spinner();
                     win.show_error_message(text);
-                    // Cancel the timeout since we're showing error now (defensive check)
                     if (win.loading_state != null) {
                         var timeout_id = win.loading_state.initial_reveal_timeout_id;
                         if (timeout_id > 0) {
@@ -179,10 +207,11 @@ public class FetchNewsController {
         });
     }
 
-    // Non-capturing global add_item used for background fetchers to
-    // safely post article additions to the main loop. This avoids
-    // passing per-fetch capturing delegates into worker threads which
-    // can be freed while the worker still holds a reference.
+    // Non-capturing so it's safe to post from background-fetcher threads onto the main
+    // loop. Don't replace this with a per-request closure carrying captured state (e.g.
+    // My Feed row identity) - closures captured on one thread and invoked later from a
+    // fetch's worker thread can arrive with garbage memory. Resolve such state from
+    // source_name/category_id in ArticleManager.add_item() instead.
     public static void global_add_item(string title, string url, string? thumbnail, string category_id, string? source_name, string? published = null, string? snippet = null) {
         Idle.add(() => {
             var cur = FetchContext.current_context();
@@ -190,21 +219,13 @@ public class FetchNewsController {
             var w = cur.window;
             if (w == null) return false;
 
-            // CRITICAL: Validate that we're still viewing the same category
-            // This prevents articles from a previous fetch appearing in a new category
-            // when the user switches categories before the fetch completes
+            // discard if the user switched categories before this fetch completed
             if (w.prefs != null && cur.expected_category != null) {
                 if (w.prefs.category != cur.expected_category) {
-                    // User switched categories - discard this article
                     return false;
                 }
             }
 
-            // When this fetch is racing multiple sources for the same view,
-            // briefly buffer articles so they can be flushed newest-first
-            // instead of in "whichever source answered first" order - unless
-            // this seq's buffer has already flushed once, in which case a
-            // late straggler just streams straight through.
             if (cur.is_multi_source && !multi_source_flushed().contains(cur.seq)) {
                 buffer_multi_source_item(cur.seq, title, url, thumbnail, category_id, source_name, published, snippet);
                 return false;
@@ -215,26 +236,19 @@ public class FetchNewsController {
         });
     }
 
-    // Non-capturing no-op clear used when we already cleared UI before
-    // scheduling individual fetches. This avoids passing per-fetch
-    // capturing clear callbacks into worker threads.
     public static void global_no_op_clear() {
-        // intentionally empty
     }
 
 
     public static void fetch_news(NewsWindow win) {
         if (win == null) return;
 
-        // === PHASE 1: Cleanup and preparation ===
         if (win.image_manager != null) win.image_manager.cleanup_stale_downloads();
 
-        // Reset article manager state (clears articles, stops carousel, cancels pending timeouts)
         if (win.article_manager != null) win.article_manager.reset_for_new_fetch();
 
-        // Clear old article tracking before fetching to prevent count accumulation
-        // Skip clearing during initial_phase (startup) so unreadFetchService counts are preserved
-        // Also skip for myfeed, local_news, and saved (which aggregate from multiple sources)
+        // skip during startup (preserves unreadFetchService counts) and for categories
+        // that aggregate from multiple sources
         bool is_initial = (win.loading_state != null && win.loading_state.initial_phase);
         if (!is_initial && win.article_state_store != null && win.prefs.category != null && win.prefs.category.length > 0) {
             string cat = win.prefs.category;
@@ -244,18 +258,13 @@ public class FetchNewsController {
             }
         }
 
-        // Prepare layout (clears hero/featured containers, rebuilds columns)
-        // NOTE: Sidebar rebuild removed - it's wasteful to rebuild on every fetch
-        // The sidebar only needs to rebuild when news sources change (in prefs), not on every category switch
-        // win.update_sidebar_for_source();
+        // sidebar rebuild only needed when sources change in prefs, not on every fetch
         bool is_topten = win.category_manager.is_topten_view();
         win.layout_manager.prepare_for_new_fetch(is_topten);
 
-        // Reset adaptive layout tracking for new fetch
         win.layout_manager.reset_adaptive_tracking();
 
-        // For regular categories that may use adaptive layout, mark that we're awaiting
-        // the adaptive layout check so the spinner stays visible until layout is finalized
+        // keep spinner visible until adaptive layout finalizes for regular categories
         bool is_regular_category = !win.category_manager.is_frontpage_view() &&
         !win.category_manager.is_topten_view() &&
         !win.category_manager.is_myfeed_category() &&
@@ -294,14 +303,10 @@ public class FetchNewsController {
         }
         win.update_content_header_now();
 
-        // Create a new FetchContext early so early timeouts can use it.
-        // This invalidates any previous context and holds a weak reference
-        // to the window for safe async access. All window access must go
-        // through FetchContext validation to avoid use-after-free.
+        // all window access below must go through FetchContext validation to avoid use-after-free
         var ctx = FetchContext.begin_new(win);
         uint my_seq = ctx.seq;
 
-        // Safety timeout: reveal after a reasonable maximum to avoid blocking forever
         if (loading_state != null) {
             loading_state.initial_reveal_timeout_id = Timeout.add(NewsWindow.INITIAL_MAX_WAIT_MS, () => {
                 if (!FetchContext.is_current(my_seq)) return false;
@@ -310,7 +315,6 @@ public class FetchNewsController {
                 var w = cur.window;
                 if (w == null) return false;
 
-                // Safely access loading_state through local variable
                 var ls = w.loading_state;
                 if (ls == null) return false;
 
@@ -322,8 +326,7 @@ public class FetchNewsController {
                         w.show_error_message();
                     }
                 } else {
-                    // CRITICAL: Don't use reveal_initial_content() - it exits early if initial_phase is false
-                    // After RSS timeout, initial_phase is already false, so directly show the container
+                    // don't use reveal_initial_content() here - it exits early once initial_phase is false
                     if (w.loading_state != null) {
                         w.loading_state.initial_phase = false;
                         w.loading_state.hero_image_loaded = false;
@@ -333,7 +336,6 @@ public class FetchNewsController {
                         w.main_content_container.set_visible(true);
                     }
 
-                    // If offline but we have cached content, show offline toast instead of error
                     var network_monitor = GLib.NetworkMonitor.get_default();
                     if (!network_monitor.get_network_available()) {
                         w.show_toast("Offline - showing cached articles");
@@ -344,21 +346,13 @@ public class FetchNewsController {
             });
         }
         
-        // Wrapped set_label: only update if this fetch is still current
         SetLabelFunc wrapped_set_label = (text) => {
-            // Schedule UI updates on the main loop to avoid touching
-            // window fields from worker threads. The Idle callback will
-            // check the context validity before applying changes.
             Idle.add(() => {
                 if (!FetchContext.is_current(my_seq)) return false;
                 var cur = FetchContext.current_context();
                 if (cur == null) return false;
                 var w = cur.window;
                 if (w == null) return false;
-                // Detect error-like labels emitted by fetchers and mark a
-                // network failure flag so the timeout can present a more
-                // specific offline message. Many fetchers call set_label
-                // with "... Error loading ..." when network issues occur.
                 if (text != null) {
                     string lower = text.down();
                     if (lower.index_of("error") >= 0 || lower.index_of("failed") >= 0) {
@@ -369,42 +363,33 @@ public class FetchNewsController {
                     }
                 }
 
-                // Use the centralized header updater which enforces the exact
-                // UI contract (icon + category, or Search Results when active).
                 w.update_content_header();
                 return false;
             });
         };
 
-        // Wrapped clear_items: only clear if this fetch is still current
-        // Ensure we only clear once per fetch: some fetchers may call the
-        // provided clear callback multiple times during retries/fallbacks.
+        // some fetchers call the clear callback multiple times during retries/fallbacks;
+        // keep this idempotent per fetch
         bool wrapped_clear_ran = false;
         ClearItemsFunc wrapped_clear = () => {
-            // Schedule the clear on the main loop to avoid worker-thread UI access
             Idle.add(() => {
                 if (!FetchContext.is_current(my_seq)) return false;
                 var cur = FetchContext.current_context();
                 if (cur == null) return false;
                 var w = cur.window;
                 if (w == null) return false;
-                // Guard: make this clear idempotent per-fetch
                 if (wrapped_clear_ran) {
                     return false;
                 }
                 wrapped_clear_ran = true;
 
-                // Log execution of wrapped_clear so we can correlate clears with fetch sequences and view
                 long _ts = (long) GLib.get_monotonic_time();
-                
-                // Clear UI via delegated managers
-                // Safely access all managers through local variables to avoid TOCTOU
+
                 var layout_mgr = w.layout_manager;
                 var article_mgr = w.article_manager;
                 var view_state_mgr = w.view_state;
                 var image_mgr = w.image_manager;
 
-                // 1. Clear Featured/Hero content
                 if (layout_mgr != null) {
                     layout_mgr.clear_featured_box();
                 }
@@ -412,27 +397,22 @@ public class FetchNewsController {
                     article_mgr.reset_featured_state();
                 }
 
-                // 2. Clear Article Columns
                 if (layout_mgr != null) {
                     layout_mgr.clear_columns();
                 }
 
-                // 3. Reset Load More state
                 if (article_mgr != null) {
                     article_mgr.clear_article_buffer();
                 }
 
-                // 4. Remove "No more articles" message
                 if (layout_mgr != null) {
                     layout_mgr.remove_end_feed_message();
                 }
 
-                // 5. Ensure any load-more button managed by ArticleManager is removed
                 if (article_mgr != null) {
                     article_mgr.clear_load_more_button();
                 }
 
-                // 6. Clear image bookkeeping
                 if (view_state_mgr != null && view_state_mgr.url_to_picture != null) {
                     view_state_mgr.url_to_picture.clear();
                 }
@@ -440,7 +420,6 @@ public class FetchNewsController {
                     image_mgr.hero_requests.clear();
                 }
 
-                // 7. Reset remaining articles state
                 if (article_mgr != null) {
                     if (article_mgr.remaining_articles != null) {
                         article_mgr.remaining_articles.clear();
@@ -452,16 +431,10 @@ public class FetchNewsController {
             });
         };
 
-        // Wrapped add_item: ignore items from stale fetches
-        // Throttled add for Local News: queue incoming items and process in small batches
         var local_news_queue = new Gee.ArrayList<ArticleItem>();
         bool local_news_flush_scheduled = false;
         int local_news_items_enqueued = 0; // debug counter
         bool local_news_stats_scheduled = false;
-        // General UI add queue to batch worker->main-thread article additions.
-        // Using a single Idle to drain this queue avoids per-item refs on the
-        // window/object and reduces thread churn that previously caused races
-        // during heavy fetches.
         var ui_add_queue = new Gee.ArrayList<ArticleItem>();
         bool ui_add_idle_scheduled = false;
 
@@ -471,16 +444,13 @@ public class FetchNewsController {
             var w = cur_start.window;
             if (w == null) return;
 
-            // CRITICAL: Validate that we're still viewing the same category
-            // This prevents articles from a previous fetch appearing in a new category
             if (w.prefs != null && cur_start.expected_category != null) {
                 if (w.prefs.category != cur_start.expected_category) {
-                    // User switched categories - discard this article
                     return;
                 }
             }
 
-            // Check article limit ONLY for limited categories, NOT frontpage/topten/all
+            // limited categories only, not frontpage/topten/all
             bool viewing_limited_category = (
                 w.prefs.category == "general" ||
                 w.prefs.category == "us" ||
@@ -498,38 +468,32 @@ public class FetchNewsController {
                 || w.prefs.category == "local_news"
                 || w.prefs.category == "myfeed"
             );
-                        
-            // Don't check limit here - let add_item_immediate_to_column() handle it after filtering
-            
-            // If we're in Local News mode, enqueue and process in small batches to avoid UI lockups
+
+            // limit is enforced later by add_item_immediate_to_column() after filtering
+
             var prefs_local = NewsPreferences.get_instance();
             if (prefs_local != null && prefs_local.category == "local_news") {
                     local_news_queue.add(new ArticleItem(title, url, thumbnail, category_id, source_name, published));
                     local_news_items_enqueued++;
                     if (!local_news_flush_scheduled) {
                         local_news_flush_scheduled = true;
-                        // Process up to 6 items per tick to keep UI responsive
                         Timeout.add(60, () => {
                             int processed = 0;
                             int batch = 6;
                             while (local_news_queue.size > 0 && processed < batch) {
                                 var ai = local_news_queue.get(0);
                                 local_news_queue.remove_at(0);
-                                // Ensure still current before adding
                                 if (!FetchContext.is_current(my_seq)) {
                                     // stale fetch; drop item
                                 } else {
                                     var cur2 = FetchContext.current_context();
                                     if (cur2 != null) {
                                         var w2 = cur2.window;
-                                        // CRITICAL: Also validate category hasn't changed
                                         if (w2 != null && w2.prefs != null && cur2.expected_category != null) {
                                             if (w2.prefs.category == cur2.expected_category) {
                                                 w2.article_manager.add_item(ai.title, ai.url, ai.thumbnail_url, ai.category_id, ai.source_name, ai.published);
                                             }
-                                            // else: user switched categories, drop this article
                                         } else if (w2 != null) {
-                                            // Fallback if expected_category is not set
                                             w2.article_manager.add_item(ai.title, ai.url, ai.thumbnail_url, ai.category_id, ai.source_name, ai.published);
                                         }
                                     }
@@ -537,12 +501,10 @@ public class FetchNewsController {
                                 processed++;
                             }
                             if (local_news_queue.size > 0) {
-                                // Keep the timeout running until the queue is drained
                                 return true;
                             } else {
                                 local_news_flush_scheduled = false;
 
-                                // Local News queue fully drained: refresh its badge now
                                 if (w.sidebar_manager != null) {
                                     w.sidebar_manager.update_badge_for_category("local_news");
                                 }
@@ -554,87 +516,59 @@ public class FetchNewsController {
                     return;
                 }
             
-            // Add the article (handles deduplication)
             w.article_manager.add_item(title, url, thumbnail, category_id, source_name, published);
         };
 
-        // Support fetching from multiple preferred sources when the user
-        // has enabled more than one in preferences. The preferences store
-        // string ids (e.g. "guardian", "reddit"). Map those to the
-        // NewsSource enum and invoke NewsService.fetch for each. Ensure
-        // we only clear the UI once (for the first fetch) so subsequent
-        // fetches append their results.
         bool used_multi = false;
-        // Use CategoryManager for My Feed logic
         bool is_myfeed_mode = win.category_manager.is_myfeed_view();
         string[] myfeed_cats = new string[0];
 
-        // Load custom RSS sources if in My Feed mode
+        // a source needs both its own "enabled" switch and the separate My Feed opt-in to be fetched here
         Gee.ArrayList<Paperboy.RssSource>? custom_rss_sources = null;
         if (is_myfeed_mode) {
             var rss_store = Paperboy.RssSourceStore.get_instance();
             var all_custom = rss_store.get_all_sources();
             custom_rss_sources = new Gee.ArrayList<Paperboy.RssSource>();
 
-            // Filter to only enabled custom sources
             foreach (var src in all_custom) {
-                if (win.prefs.preferred_source_enabled("custom:" + src.url)) {
+                if (win.prefs.preferred_source_enabled("custom:" + src.url) && win.prefs.myfeed_feed_enabled(src.url)) {
                     custom_rss_sources.add(src);
                 }
             }
         }
         
-        // Grab search query via getter
         string current_search_query = win.get_current_search_query();
 
-        // Determine up front whether this fetch will race more than one
-        // source concurrently for the same view, so FetchContext can flag it
-        // before ANY fetch starts streaming articles back - including the
-        // always-on Sports supplement immediately below, which itself races
-        // against Sports' normal per-source fetch. See the buffering block
-        // in global_add_item()/buffer_multi_source_item() for why this
-        // matters: without it, whichever source's HTTP response happens to
-        // land first wins the hero slot, even if its article is the oldest
-        // of the bunch.
+        // must be set before any fetch starts streaming back, or whichever source's HTTP
+        // response lands first wins the hero slot even if its article is oldest
         bool is_saved_view = (win.prefs.category == "saved");
         int total_sources = (win.prefs.preferred_sources != null ? win.prefs.preferred_sources.size : 0);
         if (is_myfeed_mode && custom_rss_sources != null) {
             total_sources += custom_rss_sources.size;
         }
-        // Front Page/Top Ten always issue a single backend request no matter
-        // how many sources are in preferred_sources, so they never actually
-        // race sources against each other and should not be buffered.
+        // frontpage/topten always issue one backend request regardless of source count
         bool is_frontpage_or_topten = win.category_manager.is_frontpage_view() || win.category_manager.is_topten_view();
         ctx.is_multi_source = !is_frontpage_or_topten && ((win.prefs.category == "sports") ||
             (!is_saved_view && (total_sources > 1 || (is_myfeed_mode && custom_rss_sources != null && custom_rss_sources.size > 0))));
 
-        // Persistent Sports supplement: always additionally query the
-        // backend's dedicated sports endpoint when viewing Sports, so the
-        // category isn't empty for users whose enabled built-in sources
-        // have no sports desk (e.g. PBS). This runs alongside - not instead
-        // of - the normal per-source Sports fetch below, uses a no-op clear
-        // so it never wipes articles already added, and is intentionally
-        // not gated by preferred_sources: there is no user-facing toggle
-        // for it.
+        // always query the sports endpoint too, so users whose enabled sources have no
+        // sports desk (e.g. PBS) still see content; runs alongside the normal fetch below
         if (win.prefs.category == "sports") {
             var paperboy_sports_fetcher = new PaperboyFetcher(FetchNewsController.global_forward_label, FetchNewsController.global_no_op_clear, FetchNewsController.global_add_item);
             paperboy_sports_fetcher.fetch("sports", current_search_query, win.session);
         }
 
         if (is_myfeed_mode) {
-            // Load personalized categories if configured (applies only to built-in sources)
             if (win.category_manager.is_myfeed_configured()) {
                 var cats = win.category_manager.get_myfeed_categories();
                 myfeed_cats = new string[cats.size];
                 for (int i = 0; i < cats.size; i++) myfeed_cats[i] = cats.get(i);
             }
 
-            // Check if we have ANY content to show (personalized categories OR custom RSS sources)
             bool has_personalized_cats = (myfeed_cats != null && myfeed_cats.length > 0);
             bool has_custom_rss = (custom_rss_sources != null && custom_rss_sources.size > 0);
 
             if (!has_personalized_cats && !has_custom_rss) {
-                // No personalized categories AND no custom RSS sources - nothing to show
                 wrapped_clear();
                 wrapped_set_label("My Feed — No personalized categories or custom RSS feeds configured");
                 win.hide_loading_spinner();
@@ -642,7 +576,6 @@ public class FetchNewsController {
             }
         }
 
-        // Saved Articles: delegate to FetchNewsController helper
         if (win.prefs.category == "saved") {
             if (FetchNewsController.handle_saved_articles(win, ctx, current_search_query, wrapped_set_label, wrapped_clear, wrapped_add)) return;
         }
@@ -651,25 +584,18 @@ public class FetchNewsController {
             if (FetchNewsController.handle_local_news(win, ctx, wrapped_set_label, wrapped_clear, wrapped_add, win.session, current_search_query)) return;
         }
 
-        // RSS Feed: if the user selected an individual RSS feed from the sidebar,
-        // fetch articles from that specific feed URL using the RSS parser.
         if (win.category_manager.is_rssfeed_view()) {
             if (FetchNewsController.handle_rss_feed(win, wrapped_set_label, wrapped_clear, wrapped_add, win.session, current_search_query, my_seq))
                 return;
         }
-        // If the user selected "Front Page", always request the backend
-        // frontpage endpoint regardless of preferred_sources. Place this
-        // before the multi-source branch so frontpage works even when the
-        // user has zero or one preferred source selected.
+        // handled before the multi-source branch so it works with zero/one preferred sources
         if (win.category_manager.is_frontpage_view()) {
             used_multi = true;
 
                 wrapped_clear();
-                // Debug marker: set a distinct label so we can confirm this branch runs
                 wrapped_set_label("Frontpage — Loading from backend (branch 1)");
             NewsService.fetch(win.prefs.news_source, "frontpage", current_search_query, win.session, FetchNewsController.global_forward_label, FetchNewsController.global_no_op_clear, FetchNewsController.global_add_item);
 
-            // Schedule badge refresh for frontpage
             var sidebar_mgr = win.sidebar_manager;
             if (sidebar_mgr != null) {
                 sidebar_mgr.schedule_badge_refresh("frontpage", my_seq);
@@ -677,8 +603,6 @@ public class FetchNewsController {
             return;
         }
 
-        // If the user selected "Top Ten", request the backend headlines endpoint
-        // regardless of preferred_sources. Same early-return logic as frontpage.
         if (win.category_manager.is_topten_view()) {
             used_multi = true;
 
@@ -686,7 +610,6 @@ public class FetchNewsController {
                 wrapped_set_label("Top Ten — Loading from backend");
             NewsService.fetch(win.prefs.news_source, "topten", current_search_query, win.session, FetchNewsController.global_forward_label, FetchNewsController.global_no_op_clear, FetchNewsController.global_add_item);
 
-            // Schedule badge refresh for topten
             var sidebar_mgr = win.sidebar_manager;
             if (sidebar_mgr != null) {
                 sidebar_mgr.schedule_badge_refresh("topten", my_seq);
@@ -694,15 +617,10 @@ public class FetchNewsController {
             return;
         }
 
-        // Check if we should use multi-source mode (multiple built-in sources OR custom RSS sources in My Feed)
-        // Skip multi-source mode for saved articles, local news, and individual RSS feeds - they have their own header setup
-        // (is_saved_view/total_sources computed earlier, alongside ctx.is_multi_source)
+        // saved articles, local news, and individual RSS feeds have their own header setup above
         if (!is_saved_view && (total_sources > 1 || (is_myfeed_mode && custom_rss_sources != null && custom_rss_sources.size > 0))) {
-            // Treat The Frontpage as a multi-source view visually, but do NOT
-            // let the user's preferred_sources list influence which providers
-            // are queried. Instead, when viewing the special "frontpage"
-            // category, simply request the backend frontpage once and present
-            // the combined/multi-source UI.
+            // frontpage is visually a multi-source view, but preferred_sources shouldn't
+            // influence which providers get queried - just hit the backend frontpage endpoint once
             if (win.category_manager.is_frontpage_view()) {
                 used_multi = true;
 
@@ -720,14 +638,12 @@ public class FetchNewsController {
                 return;
             }
 
-            // Same logic for Top Ten: request backend headlines endpoint
             if (win.category_manager.is_topten_view()) {
                 used_multi = true;
 
                 wrapped_clear();
                 NewsService.fetch(win.prefs.news_source, "topten", current_search_query, win.session, FetchNewsController.global_forward_label, FetchNewsController.global_no_op_clear, FetchNewsController.global_add_item);
-                
-                // Schedule badge refresh for topten
+
                 var sidebar_mgr = win.sidebar_manager;
                 if (sidebar_mgr != null) {
                     sidebar_mgr.schedule_badge_refresh("topten", my_seq);
@@ -737,10 +653,8 @@ public class FetchNewsController {
 
             used_multi = true;
 
-            //Use SourceManager to get enabled sources as enums
             Gee.ArrayList<NewsSource> srcs = win.source_manager.get_enabled_source_enums();
 
-            // If mapping failed or produced no sources, fall back to single source
             if (srcs.size == 0) {
                 NewsService.fetch(
                     win.prefs.news_source,
@@ -752,19 +666,12 @@ public class FetchNewsController {
                     FetchNewsController.global_add_item
                 );
             } else {
-                // Filter the selected sources to those that actually support
-                // the requested category. Special-case the personalized
-                // My Feed mode: prefs.category == "myfeed" is not a real
-                // provider category, so check per-personalized-category
-                // support (e.g., Bloomberg supports markets/industries but
-                // not a generic "myfeed"). This ensures Bloomberg isn't
-                // excluded from the combined fetch when the user has
-                // selected Bloomberg-specific personalized categories.
+                // "myfeed" isn't a real provider category, so check support per personalized
+                // category instead (e.g. Bloomberg supports markets/industries but not "myfeed")
                 var filtered = new Gee.ArrayList<NewsSource>();
                 foreach (var s in srcs) {
                     bool include = false;
                     if (is_myfeed_mode) {
-                        // If no personalized categories selected, be permissive
                         if (myfeed_cats == null || myfeed_cats.length == 0) {
                             include = true;
                         } else {
@@ -778,19 +685,11 @@ public class FetchNewsController {
                     if (include) filtered.add(s);
                 }
 
-                // If filtering removed all sources (unlikely), fall back to original
-                // list so we at least attempt to fetch something.
                 var use_srcs = filtered.size > 0 ? filtered : srcs;
 
-                // Clear the UI once up-front so we don't race with asynchronous
-                // fetch completions (a later-completing fetch shouldn't be able
-                // to wipe results added by an earlier one).
+                // clear once up front so a later-completing fetch can't wipe an earlier one's results
                 wrapped_clear();
 
-                // Use a no-op clear for all individual fetches since we've
-                // already cleared above. Keep a combined label while in multi
-                // source mode. If we're in My Feed personalized mode, request
-                // each personalized category separately and combine results.
                 ClearItemsFunc no_op_clear = () => { };
                 SetLabelFunc label_fn = (text) => {
                         Idle.add(() => {
@@ -804,7 +703,6 @@ public class FetchNewsController {
                         });
                 };
 
-                // Fetch from built-in sources (unless in My Feed with custom_only mode enabled)
                 bool skip_builtin = is_myfeed_mode && win.prefs.myfeed_custom_only;
                 if (!skip_builtin) {
                     foreach (var s in use_srcs) {
@@ -818,24 +716,20 @@ public class FetchNewsController {
                     }
                 }
 
-                // Schedule badge refresh for non-myfeed categories after articles register
                 if (!is_myfeed_mode) {
                     var sidebar_mgr = win.sidebar_manager;
                     if (sidebar_mgr != null) {
                         sidebar_mgr.schedule_badge_refresh(win.prefs.category, my_seq);
                     }
-                    // Adaptive layout is now handled by track_category_article() for regular categories
                 }
 
-                // Fetch from custom RSS sources if in My Feed mode and sources are enabled
                 if (is_myfeed_mode && custom_rss_sources != null && custom_rss_sources.size > 0) {
-                    // Don't set featured_used - allow first article to become hero/carousel
                     foreach (var rss_src in custom_rss_sources) {
-                        // For generated feeds (file:// URLs), use original_url as cache key for persistence across regenerations
+                        // generated feeds (file:// URLs) use original_url as cache key so it survives regeneration
                         string? cache_key = (rss_src.url.has_prefix("file://") && rss_src.original_url != null) ? rss_src.original_url : null;
                         RssFeedProcessor.fetch_rss_url(
                             rss_src.url,
-                            rss_src.url,  // Pass URL instead of name for proper source filtering
+                            rss_src.url,  // use URL, not name, for source filtering
                             "My Feed",
                             "myfeed",
                             current_search_query,
@@ -849,17 +743,11 @@ public class FetchNewsController {
                 }
             }
         } else {
-            // Single-source path: keep existing behavior. Use the
-            // effective source so a single selected preferred_source is
-            // respected without requiring prefs.news_source to be changed.
-            // Special-case: when viewing The Frontpage in single-source
-            // mode, make sure we still request the backend frontpage API.
             if (win.category_manager.is_frontpage_view()) {
                 wrapped_clear();
                 wrapped_set_label("Frontpage — Loading from backend (single-source)");
                 NewsService.fetch(win.prefs.news_source, "frontpage", current_search_query, win.session, FetchNewsController.global_forward_label, FetchNewsController.global_no_op_clear, FetchNewsController.global_add_item);
-                
-                // Schedule badge refresh for frontpage
+
                 var sidebar_mgr = win.sidebar_manager;
                 if (sidebar_mgr != null) {
                     sidebar_mgr.schedule_badge_refresh("frontpage", my_seq);
@@ -867,13 +755,11 @@ public class FetchNewsController {
                 return;
             }
 
-            // Same for Top Ten in single-source mode
             if (win.category_manager.is_topten_view()) {
                 wrapped_clear();
                 wrapped_set_label("Top Ten — Loading from backend (single-source)");
                 NewsService.fetch(win.prefs.news_source, "topten", current_search_query, win.session, FetchNewsController.global_forward_label, FetchNewsController.global_no_op_clear, FetchNewsController.global_add_item);
-                
-                // Schedule badge refresh for topten
+
                 var sidebar_mgr = win.sidebar_manager;
                 if (sidebar_mgr != null) {
                     sidebar_mgr.schedule_badge_refresh("topten", my_seq);
@@ -882,7 +768,6 @@ public class FetchNewsController {
             }
 
             if (is_myfeed_mode) {
-                // Fetch each personalized category for the single effective source
                 wrapped_clear();
                 ClearItemsFunc no_op_clear = () => { };
                 SetLabelFunc label_fn = (text) => {
@@ -908,11 +793,10 @@ public class FetchNewsController {
                 if (custom_rss_sources != null && custom_rss_sources.size > 0) {
                     win.article_manager.featured_used = true;
                     foreach (var rss_src in custom_rss_sources) {
-                        // For generated feeds (file:// URLs), use original_url as cache key for persistence across regenerations
                         string? cache_key = (rss_src.url.has_prefix("file://") && rss_src.original_url != null) ? rss_src.original_url : null;
                         RssFeedProcessor.fetch_rss_url(
                             rss_src.url,
-                            rss_src.url,  // Pass URL instead of name for proper source filtering
+                            rss_src.url,  // use URL, not name, for source filtering
                             "My Feed",
                             "myfeed",
                             current_search_query,
@@ -935,8 +819,6 @@ public class FetchNewsController {
                     }
                 }
 
-                // Schedule a one-shot badge refresh for My Feed after initial
-                // results have had a chance to register in ArticleStateStore.
                 var sidebar_mgr = win.sidebar_manager;
                 if (sidebar_mgr != null) {
                     sidebar_mgr.schedule_badge_refresh("myfeed", my_seq);
@@ -953,28 +835,22 @@ public class FetchNewsController {
                     FetchNewsController.global_add_item
                 );
 
-                // Schedule badge refresh for this category after articles register
                 var sidebar_mgr = win.sidebar_manager;
                 if (sidebar_mgr != null) {
                     sidebar_mgr.schedule_badge_refresh(win.prefs.category, my_seq);
                 }
-                // Adaptive layout is now handled by track_category_article() for regular categories
             }
         }
     }
 
-    // Schedule a post-fetch check for adaptive layout based on actual article count
-    // This approach works regardless of source count since it uses deduplicated ArticleStateStore data
     public static void schedule_adaptive_layout_check(NewsWindow win, uint my_seq) {
-        // Check immediately when articles are populated, then again after a delay
-        // This ensures we catch the layout decision before the spinner tries to hide
+        // check immediately, then again after a delay in case articles are still registering
         Idle.add(() => {
             if (!FetchContext.is_current(my_seq)) return false;
             perform_adaptive_check(win, my_seq);
             return false;
         });
 
-        // Also schedule a delayed check in case articles are still being registered
         Timeout.add(600, () => {
             if (!FetchContext.is_current(my_seq)) return false;
             perform_adaptive_check(win, my_seq);

--- a/src/ui/dialogs/prefsDialog.vala
+++ b/src/ui/dialogs/prefsDialog.vala
@@ -1393,6 +1393,14 @@ public class PrefsDialog : GLib.Object {
     // Condensed highlights for the 5 most recent GitHub releases, shown in
     // the About dialog's "What's New" page.
     private const string RELEASE_NOTES = """
+        <p><em>v0.8.1a</em> — My Feed Redesign, Memory Fixes &amp; Row Navigation</p>
+        <ul>
+        <li>Redesigned My Feed as interleaved source/category rows, mirroring Front Page's card layout, with custom RSS feeds able to opt in independently via a new Personalization subpage</li>
+        <li>Fixed a memory/freeze regression from that redesign by capping live card widgets per row and tightening HTTP concurrency</li>
+        <li>Fixed built-in sources disappearing from My Feed under load, and circular logos being stretched instead of center-cropped</li>
+        <li>Fixed Sports' hero carousel staying empty on first load, and My Feed's sidebar unread badge showing inflated counts</li>
+        <li>Added a "Go to category" button on Front Page/My Feed rows for quick navigation to the full category page</li>
+        </ul>
         <p><em>v0.8.0a</em> — Live Sports Scores, UI Redesign &amp; Major Performance Overhaul</p>
         <ul>
         <li>Added live ESPN scoreboard cards to the Sports category, covering major leagues from the NFL to Champions League, with polling that scales to game state</li>
@@ -1420,26 +1428,20 @@ public class PrefsDialog : GLib.Object {
         <li>Generated RSS feeds keep a stable cache across regenerations</li>
         <li>Centralized offline detection to avoid dead-end network actions</li>
         </ul>
-        <p><em>v0.7.2a</em> — Feature &amp; Polish Update</p>
-        <ul>
-        <li>Added back/forward/reload navigation to the in-app article viewer</li>
-        <li>Added a "mark as unread" option to the article context menu</li>
-        <li>Fixed Frontpage cards briefly appearing in the wrong section</li>
-        </ul>
         """;
 
     public static void show_about_dialog(Gtk.Window parent) {
         var about = new Adw.AboutDialog();
         about.set_application_name("Paperboy");
         about.set_application_icon("paperboy"); // Use the correct icon name
-        about.set_version("0.8.0a");
+        about.set_version("0.8.1a");
         about.set_developer_name("thecalamityjoe87 (Isaac Joseph)");
         about.set_comments("A simple news app written in Vala, built with GTK4 and Libadwaita.");
         about.set_website("https://github.com/thecalamityjoe87/paperboy");
         about.set_license_type(Gtk.License.GPL_3_0);
         about.set_copyright("© 2025 thecalamityjoe87 (Isaac Joseph)");
 
-        about.set_release_notes_version("0.8.0a");
+        about.set_release_notes_version("0.8.1a");
         about.set_release_notes(RELEASE_NOTES);
 
         about.set_issue_url("https://github.com/thecalamityjoe87/paperboy/issues");

--- a/src/ui/dialogs/prefsDialog.vala
+++ b/src/ui/dialogs/prefsDialog.vala
@@ -21,11 +21,8 @@ using Adw;
 using Soup;
 using Gdk;
 
-// Bound directly to the C symbol rather than through Gtk.DragIcon.get_for_drag
-// because different GTK4 minor versions ship vapi bindings for it in
-// incompatible shapes (a plain static method vs. a named constructor),
-// which breaks compiling the same source against multiple GTK4/vala SDKs
-// (e.g. the system toolchain vs. the flatpak runtime's).
+// Bound directly to the C symbol since GTK4 minor versions ship
+// Gtk.DragIcon.get_for_drag's vapi binding in incompatible shapes.
 [CCode (cname = "gtk_drag_icon_get_for_drag")]
 private static extern unowned Gtk.Widget prefs_dialog_drag_icon_get_for_drag(Gdk.Drag drag);
 
@@ -352,7 +349,7 @@ public class PrefsDialog : GLib.Object {
     }
 
     // Libadwaita preferences dialog using Adw.PreferencesDialog with tabs
-    public static void show_preferences_dialog(Gtk.Window parent) {
+    public static void show_preferences_dialog(Gtk.Window parent, bool open_personalization = false) {
         var win = (NewsWindow) parent;
         var prefs = NewsPreferences.get_instance();
 
@@ -809,6 +806,142 @@ public class PrefsDialog : GLib.Object {
         });
         app_group.add(personalized_row);
 
+        // Separate place (its own row, its own slide-in page) for choosing
+        // which followed custom RSS feeds show up in My Feed - deliberately
+        // not folded into the "Personalized Feed Categories" dialog above.
+        // Pushed as an Adw.NavigationPage via the PreferencesDialog's own
+        // push_subpage() rather than opened as a separate modal dialog, so
+        // it slides in/out like any other libadwaita preferences subpage.
+        //
+        // A local closure (not a static method) so it can reuse the
+        // favicon-loading helpers (create_favicon_picture/
+        // load_favicon_circular/try_load_icon_circular) already defined
+        // above in this function, the same ones the "Feeds" section below
+        // uses for its own favicons - giving these rows the same icons
+        // instead of none.
+        bool myfeed_feeds_subpage_open = false;
+        Adw.NavigationPage build_myfeed_feeds_page() {
+            var page = new Adw.PreferencesPage();
+            var group = new Adw.PreferencesGroup();
+            group.set_description("Choose which of your followed RSS feeds appear in My Feed");
+
+            var myfeed_rss_store = Paperboy.RssSourceStore.get_instance();
+            var enabled_feeds = new Gee.ArrayList<Paperboy.RssSource>();
+            foreach (var src in myfeed_rss_store.get_all_sources()) {
+                if (prefs.preferred_source_enabled("custom:" + src.url)) enabled_feeds.add(src);
+            }
+
+            if (enabled_feeds.size == 0) {
+                var empty_row = new Adw.ActionRow();
+                empty_row.set_title("No feeds followed yet");
+                empty_row.set_subtitle("Follow a custom RSS feed in Preferences -> Feeds first, then come back here to include it in My Feed.");
+                group.add(empty_row);
+            } else {
+                foreach (var src in enabled_feeds) {
+                    string feed_url = src.url;
+                    var frow = new Adw.ActionRow();
+                    // Escape before set_title(): ActionRow parses this as
+                    // Pango markup, so an unescaped "&" (e.g. "Food & Wine")
+                    // breaks the parser and the title renders blank instead
+                    // of erroring - same fix already applied to the "Feeds"
+                    // section's rows below.
+                    frow.set_title(GLib.Markup.escape_text(src.name ?? ""));
+
+                    // Same favicon priority order as the "Feeds" section:
+                    // saved local file, then SourceMetadata's logo URL,
+                    // then Google's favicon service, then the RSS source's
+                    // own favicon_url.
+                    var wrapper = create_favicon_picture("placeholder:myfeed-feed:%s".printf(feed_url), null);
+                    Gtk.Picture? picture = null;
+                    if (wrapper is Gtk.Box) {
+                        var wbox = (Gtk.Box) wrapper;
+                        var child = wbox.get_first_child();
+                        if (child is Gtk.Picture) picture = (Gtk.Picture) child;
+                    }
+                    if (picture != null) {
+                        bool icon_loaded = false;
+                        string? icon_filename = SourceMetadata.get_saved_filename_for_source(src.name);
+                        if (icon_filename != null && icon_filename.length > 0) {
+                            var data_dir = GLib.Environment.get_user_data_dir();
+                            var icon_path = GLib.Path.build_filename(data_dir, "paperboy", "source_logos", icon_filename);
+                            if (GLib.FileUtils.test(icon_path, GLib.FileTest.EXISTS)) {
+                                try_load_icon_circular(icon_path, picture);
+                                icon_loaded = true;
+                            }
+                        }
+                        if (!icon_loaded) {
+                            string? meta_logo_url = SourceMetadata.get_logo_url_for_source(src.name);
+                            if (meta_logo_url != null && meta_logo_url.length > 0 &&
+                                (meta_logo_url.has_prefix("http://") || meta_logo_url.has_prefix("https://"))) {
+                                load_favicon_circular(picture, meta_logo_url);
+                                icon_loaded = true;
+                            }
+                        }
+                        if (!icon_loaded) {
+                            string? host = UrlUtils.extract_host_from_url(feed_url);
+                            if (host != null && host.length > 0) {
+                                load_favicon_circular(picture, "https://www.google.com/s2/favicons?domain=" + host + "&sz=128");
+                                icon_loaded = true;
+                            }
+                        }
+                        if (!icon_loaded && src.favicon_url != null && src.favicon_url.length > 0 &&
+                            (src.favicon_url.has_prefix("http://") || src.favicon_url.has_prefix("https://"))) {
+                            load_favicon_circular(picture, src.favicon_url);
+                        }
+                    }
+                    frow.add_prefix(wrapper);
+
+                    var fswitch = new Gtk.Switch();
+                    fswitch.set_active(prefs.myfeed_feed_enabled(feed_url));
+                    fswitch.set_valign(Gtk.Align.CENTER);
+
+                    string _furl = feed_url;
+                    fswitch.notify["active"].connect(() => {
+                        prefs.set_myfeed_feed_enabled(_furl, fswitch.get_active());
+                        prefs.save_config();
+                        categories_holder.changed = true;
+
+                        var myfeed_win = parent as NewsWindow;
+                        if (myfeed_win != null) {
+                            UnreadFetchService.refresh_myfeed_metadata(myfeed_win);
+                        }
+                    });
+
+                    frow.add_suffix(fswitch);
+                    frow.set_activatable(true);
+                    frow.activated.connect(() => {
+                        fswitch.set_active(!fswitch.get_active());
+                    });
+                    group.add(frow);
+                }
+            }
+
+            page.add(group);
+
+            // Adw.HeaderBar shows its own contextual back chevron once inside
+            // pushed-subpage content - wrap in one for that, but don't add a
+            // manual back button too or it doubles up.
+            var toolbar_view = new Adw.ToolbarView();
+            toolbar_view.add_top_bar(new Adw.HeaderBar());
+            toolbar_view.set_content(page);
+
+            var nav_page = new Adw.NavigationPage(toolbar_view, "Custom feeds in My Feed");
+            nav_page.hidden.connect(() => { myfeed_feeds_subpage_open = false; });
+            return nav_page;
+        }
+
+        var myfeed_feeds_row = new Adw.ActionRow();
+        myfeed_feeds_row.set_title("Custom feeds in My Feed");
+        myfeed_feeds_row.set_subtitle("Choose which followed RSS feeds appear in My Feed");
+        myfeed_feeds_row.add_suffix(new Gtk.Image.from_icon_name("go-next-symbolic"));
+        myfeed_feeds_row.set_activatable(true);
+        myfeed_feeds_row.activated.connect(() => {
+            if (myfeed_feeds_subpage_open) return;
+            myfeed_feeds_subpage_open = true;
+            dialog.push_subpage(build_myfeed_feeds_page());
+        });
+        app_group.add(myfeed_feeds_row);
+
         // Custom sources only toggle
         var custom_only_row = new Adw.SwitchRow();
         custom_only_row.set_title("Custom sources only in My Feed");
@@ -1247,6 +1380,10 @@ public class PrefsDialog : GLib.Object {
                 });
             }
         });
+
+        if (open_personalization) {
+            dialog.set_visible_page(personalization_page);
+        }
 
         // Present the dialog
         dialog.present(parent);

--- a/src/ui/sidebarView.vala
+++ b/src/ui/sidebarView.vala
@@ -612,7 +612,6 @@ public class SidebarView : GLib.Object {
 
     private Gtk.Widget build_badge_widget(int count, bool is_source, string item_id) {
         var label = new Gtk.Label(null);
-        set_badge_count_text(label, count);
         label.add_css_class("unread-count-badge");
         // Wider gap before the count on Feeds/Popular Categories rows,
         // not on the special items.
@@ -631,9 +630,21 @@ public class SidebarView : GLib.Object {
         // itself to the right edge makes every count - 1 digit or several -
         // share the same ones-place column, with no per-row margin needed.
         label.set_xalign(1.0f);
-        label.set_data("unread_count", count);
-        label.set_data("is_placeholder", false);
-        label.set_visible(badge_type_enabled(is_source, item_id) && count > 0);
+
+        // -1 is the "not visited yet" placeholder (see get_unread_count_for_item) -
+        // matches on_badge_updated()'s handling of the same sentinel for
+        // updates after creation.
+        if (count == -1) {
+            label.set_label("--");
+            label.set_data("unread_count", 0);
+            label.set_data("is_placeholder", true);
+            label.set_visible(badge_type_enabled(is_source, item_id));
+        } else {
+            set_badge_count_text(label, count);
+            label.set_data("unread_count", count);
+            label.set_data("is_placeholder", false);
+            label.set_visible(badge_type_enabled(is_source, item_id) && count > 0);
+        }
         return label;
     }
     

--- a/src/utils/httpClientUtils.vala
+++ b/src/utils/httpClientUtils.vala
@@ -29,8 +29,7 @@ using GLib;
 namespace Paperboy {
 
 public class HttpClientUtils : Object {
-    // Singleton instance (eagerly constructed at program startup to avoid
-    // lazy-construction races across threads)
+    // Eagerly constructed to avoid lazy-init races across threads.
     private static HttpClientUtils _instance = new HttpClientUtils();
 
     // HTTP session (reused for connection pooling)
@@ -39,7 +38,9 @@ public class HttpClientUtils : Object {
     // Concurrency control
     private static GLib.Mutex _request_mutex = new GLib.Mutex();
     private static int _active_requests = 0;
-    private const int MAX_CONCURRENT_REQUESTS = 8;
+    // Balances My Feed's fan-out against glibc malloc arena contention
+    // from concurrent XML/image decoding (see mallopt in main.vala).
+    private const int MAX_CONCURRENT_REQUESTS = 16;
 
     // Thread pool for request processing (reduces thread spawning overhead)
     private ThreadPool<HttpTask>? thread_pool;
@@ -167,30 +168,16 @@ public class HttpClientUtils : Object {
     public delegate void HttpResponseCallback(HttpResponse response);
 
 
-    // Get singleton instance
     public static HttpClientUtils get_default() {
-        // Ensure the GType for HttpClientUtils is initialized so the class
-        // initializer has run and `_instance` is set. This avoids a race
-        // where worker threads call `get_default()` before the GType
-        // system has created the singleton in `class_init`.
-        // Use `typeof(HttpClientUtils)` to reference the GType and force
-        // Vala/GLib to register the type before returning the instance.
+        // Forces GType registration so class_init has run and _instance is set,
+        // even if a worker thread gets here first.
         var _type = typeof (HttpClientUtils);
-
-        // Return the static singleton instance directly. The instance is
-        // constructed by the class initializer and intentionally never
-        // finalized to avoid cross-thread initialization/finalization races.
         return _instance;
     }
 
-    // Force initialization of the singleton from the calling thread.
-    // Call this from the main thread at startup to ensure the GType
-    // class initializer runs and the singleton is created before any
-    // worker threads can call `get_default()`.
+    // Call from the main thread at startup so the singleton exists before
+    // any worker thread races to get_default().
     public static void ensure_initialized() {
-        // Force the GType to be registered and the class initializer
-        // to run. This helps ensure `_instance` is set before any
-        // worker thread can call `get_default()`.
         var _type = typeof (HttpClientUtils);
 
         if (_instance == null) {
@@ -199,35 +186,23 @@ public class HttpClientUtils : Object {
     }
 
 
-    // Private constructor (singleton pattern)
     private HttpClientUtils() {
-        // Create HTTP session with keep-alive and connection pooling
+        // Plain constructor only: setting max-conns/max-conns-per-host via
+        // GLib.Object.new() property varargs crashes libsoup under
+        // concurrent use, so we're stuck with its default per-host limits.
         session = new Soup.Session() {
             timeout = TIMEOUT_DEFAULT
         };
 
-        // Initialize request deduplication cache
         in_flight_requests = new Gee.HashMap<string, RequestState>();
 
-        // Thread pool will be created lazily on first async fetch to avoid
-        // spawning worker threads during singleton construction which can
-        // cause reentrancy and mutex initialization races.
+        // Created lazily on first async fetch to avoid spawning threads
+        // during singleton construction.
         thread_pool = null;
     }
 
 
-    // Process HTTP task in thread pool
     private void process_http_task(owned HttpTask task) {
-        // Throttle concurrent requests
-        _request_mutex.lock();
-        while (_active_requests >= MAX_CONCURRENT_REQUESTS) {
-            _request_mutex.unlock();
-            Thread.usleep(50000); // 50ms
-            _request_mutex.lock();
-        }
-        _active_requests++;
-        _request_mutex.unlock();
-
         HttpResponse response = fetch_sync_internal(task.url, task.options);
 
         if (task.callback != null) {
@@ -236,6 +211,21 @@ public class HttpClientUtils : Object {
                 return false;
             });
         }
+    }
+
+    // Block until a request slot is free, then claim it.
+    private static void acquire_request_slot() {
+        _request_mutex.lock();
+        while (_active_requests >= MAX_CONCURRENT_REQUESTS) {
+            _request_mutex.unlock();
+            Thread.usleep(50000); // 50ms
+            _request_mutex.lock();
+        }
+        _active_requests++;
+        _request_mutex.unlock();
+    }
+
+    private static void release_request_slot() {
         _request_mutex.lock();
         _active_requests--;
         _request_mutex.unlock();
@@ -297,8 +287,7 @@ public class HttpClientUtils : Object {
             state = new RequestState();
             in_flight_requests.set(url, state);
             
-            // MEMORY SAFETY: Prevent unbounded cache growth by clearing old entries
-            // if cache exceeds reasonable size (100 concurrent requests)
+            // Cap cache growth: clear the oldest completed half once we exceed this.
             const int MAX_CACHE_SIZE = 100;
             if (in_flight_requests.size > MAX_CACHE_SIZE) {
                 // Clear oldest half of entries to avoid frequent clears
@@ -320,6 +309,11 @@ public class HttpClientUtils : Object {
             cache_mutex.unlock();
         }
 
+        // Only the actual network attempt counts against the concurrency
+        // cap; dedup hits above already returned. finally covers all early
+        // returns so every caller is bounded the same way.
+        acquire_request_slot();
+        try {
         try {
             // Create request
             var msg = new Soup.Message(options.method, url);
@@ -450,6 +444,9 @@ public class HttpClientUtils : Object {
                 }
                 cache_mutex.unlock();
             }
+        }
+        } finally {
+            release_request_slot();
         }
 
         return response;

--- a/src/utils/pixbufUtils.vala
+++ b/src/utils/pixbufUtils.vala
@@ -20,13 +20,9 @@ using GLib;
 using Cairo;
 
 public class PixbufUtils {
-    // Scale to square (out_size x out_size) and mask to a circle (alpha
-    // outside = 0). border_width (in the same pixel space as out_size), if
-    // > 0, strokes a subtle ring around the circle's edge - without it, a
-    // logo whose own colors are close to the background it sits on (e.g. a
-    // mostly-white or mostly-transparent logo in light mode) can look like
-    // it has no circle at all, since the white circular backdrop below
-    // blends straight into the page.
+    // Scales to a square and masks to a circle. border_width, if > 0,
+    // strokes a ring around the edge so light/transparent logos don't
+    // blend into the page.
     public static Gdk.Pixbuf? scale_and_circularize (Gdk.Pixbuf? src, int out_size, double border_width = 0) {
         if (src == null) return null;
 
@@ -34,30 +30,28 @@ public class PixbufUtils {
         int h = src.get_height();
         int src_size = (w < h) ? w : h;
 
-        // Create a square pixbuf scaled to out_size then paint it into a
-        // Cairo ARGB surface clipped to a circle. Converting the surface
-        // back to a pixbuf avoids accessing raw pixel memory directly.
-        Gdk.Pixbuf scaled_pb;
-                // Scale the source pixbuf to the desired output size
-        scaled_pb = src.scale_simple (out_size, out_size, Gdk.InterpType.BILINEAR);
+        // Center-crop to a square on the shorter dimension so non-square
+        // logos (e.g. wide wordmarks) don't get stretched.
+        int crop_x = (w - src_size) / 2;
+        int crop_y = (h - src_size) / 2;
+        Gdk.Pixbuf square_src = new Gdk.Pixbuf.subpixbuf(src, crop_x, crop_y, src_size, src_size);
 
-        // Create ARGB surface and draw a circular badge with the logo
+        Gdk.Pixbuf scaled_pb;
+        scaled_pb = square_src.scale_simple (out_size, out_size, Gdk.InterpType.BILINEAR);
+
         var surface = new ImageSurface(Format.ARGB32, out_size, out_size);
         var cr = new Context(surface);
 
-        // Fill transparent first
         cr.set_source_rgba(0, 0, 0, 0);
         cr.paint();
 
-        // Use a slight inset (0.5) and best antialiasing to produce a
-        // visually-crisp circle across different scale factors / DPI.
+        // Slight inset keeps the circle crisp across scale factors/DPI.
         cr.set_antialias(Antialias.BEST);
         double inset_f = 0.5;
         double radius = (out_size - (inset_f * 2.0)) / 2.0;
         double cx = out_size / 2.0;
         double cy = out_size / 2.0;
 
-        // Draw solid circular background (white) so the badge is opaque.
         cr.arc(cx, cy, radius, 0, 2 * Math.PI);
         cr.set_source_rgba(1, 1, 1, 1);
         cr.fill();
@@ -66,20 +60,10 @@ public class PixbufUtils {
         cr.arc(cx, cy, radius, 0, 2 * Math.PI);
         cr.clip();
 
-        // Draw the scaled pixbuf inset slightly so it sits comfortably inside the badge
-        int inset = 4; // matches previous code that centered a 16x16 inside 24x24
-        int inner_size = out_size - (inset * 2);
-        Gdk.Pixbuf inner_pb;
-        inner_pb = scaled_pb.scale_simple(inner_size, inner_size, Gdk.InterpType.BILINEAR);
-
-        int ox = inset;
-        int oy = inset;
-        Gdk.cairo_set_source_pixbuf(cr, inner_pb, ox, oy);
+        Gdk.cairo_set_source_pixbuf(cr, scaled_pb, 0, 0);
         cr.paint();
 
-        // Stroke a subtle ring around the edge, outside the fill clip
-        // above (reset_clip so the full stroke width is visible rather
-        // than just its inward half).
+        // reset_clip so the stroke isn't half-clipped by the fill clip above.
         if (border_width > 0) {
             cr.reset_clip();
             cr.set_line_width(border_width);
@@ -88,38 +72,19 @@ public class PixbufUtils {
             cr.stroke();
         }
 
-        // Convert surface back to pixbuf
         var result_pb = Gdk.pixbuf_get_from_surface(surface, 0, 0, out_size, out_size);
         return result_pb;
     }
 
-    // Logos are rendered at this many times `display_size` and then scaled
-    // back down into that logical box via CONTAIN, rather than rendered at
-    // exactly display_size and shown 1:1 - a 1:1 texture only has enough
-    // pixels for a 1x display, so on any HiDPI screen (scale factor 2+)
-    // GTK has to upscale it to fill the physical pixels, which is what
-    // made these logos look blurry. Supersampling first means there's
-    // always more source detail than the box needs, so GTK downsamples
-    // (sharp) instead of upsampling (blurry) at every scale factor.
+    // Render at this multiple of display_size and let GTK downsample, so
+    // HiDPI screens get sharp scaling instead of upsampling a 1:1 texture.
     private const int LOGO_RENDER_SCALE = 3;
 
-    // Neutral gray circle the same size/shape a fetched logo will end up
-    // as, baked into the pixels (not CSS) so it stays circular regardless
-    // of the widget/theme it's dropped into. Used as the initial contents
-    // of the returned Gtk.Image before its real logo has loaded (or if it
-    // never does).
-    //
-    // Gtk.Image (not Gtk.Picture) + set_pixel_size, same as every other
-    // fixed-size icon in this codebase (see categoryIconsUtils.vala,
-    // sidebarView.vala, etc.) - pixel_size pins BOTH the widget's minimum
-    // and natural size to exactly display_size regardless of the backing
-    // texture's actual resolution. Gtk.Picture has no equivalent: its
-    // natural size always follows the paintable's real pixel dimensions,
-    // and size_request is only a floor, not a ceiling - any container with
-    // spare room (an Adw.ActionRow prefix, sized for the row's full
-    // title+subtitle height) was free to grant it that larger natural
-    // size, which is why supersampling it for sharpness (see
-    // LOGO_RENDER_SCALE) also made it balloon past display_size.
+    // Gtk.Image + set_pixel_size (not Gtk.Picture) pins both min and
+    // natural size to display_size regardless of the backing texture's
+    // resolution; Gtk.Picture's natural size follows the paintable's real
+    // pixel size, which would let a supersampled texture balloon past
+    // display_size in a container with spare room.
     public static Gtk.Image make_circular_logo_placeholder(int display_size) {
         int render_size = display_size * LOGO_RENDER_SCALE;
         var surface = new ImageSurface(Format.ARGB32, render_size, render_size);
@@ -144,11 +109,6 @@ public class PixbufUtils {
         return image;
     }
 
-    // Fetches `url`, circularizes it at display_size * LOGO_RENDER_SCALE
-    // (see make_circular_logo_placeholder), and swaps it into `image` in
-    // place of whatever placeholder it's showing. Same one-off
-    // fetch-and-forget approach as ScoreCard.load_team_logo: leaves the
-    // placeholder showing on any failure rather than erroring.
     public static void load_circular_logo_async(Gtk.Image image, string url, int display_size) {
         int render_size = display_size * LOGO_RENDER_SCALE;
         Paperboy.HttpClientUtils.get_default().fetch_bytes(url, null, (response) => {
@@ -166,5 +126,18 @@ public class PixbufUtils {
                 // Leave the placeholder showing.
             }
         });
+    }
+
+    // Same as load_circular_logo_async but synchronous, for local files.
+    public static void load_circular_logo_from_file(Gtk.Image image, string file_path, int display_size) {
+        int render_size = display_size * LOGO_RENDER_SCALE;
+        try {
+            var pixbuf = new Gdk.Pixbuf.from_file(file_path);
+            var circular = scale_and_circularize(pixbuf, render_size, LOGO_RENDER_SCALE);
+            if (circular == null) return;
+            image.set_from_paintable(Gdk.Texture.for_pixbuf(circular));
+        } catch (GLib.Error e) {
+            // Leave the placeholder showing.
+        }
     }
 }

--- a/src/utils/pixbufUtils.vala
+++ b/src/utils/pixbufUtils.vala
@@ -123,7 +123,7 @@ public class PixbufUtils {
                 if (circular == null) return;
                 image.set_from_paintable(Gdk.Texture.for_pixbuf(circular));
             } catch (GLib.Error e) {
-                // Leave the placeholder showing.
+                warning("Failed to load logo %s: %s", url, e.message);
             }
         });
     }
@@ -137,7 +137,7 @@ public class PixbufUtils {
             if (circular == null) return;
             image.set_from_paintable(Gdk.Texture.for_pixbuf(circular));
         } catch (GLib.Error e) {
-            // Leave the placeholder showing.
+            warning("Failed to load logo %s: %s", file_path, e.message);
         }
     }
 }


### PR DESCRIPTION
This pull request reworks My Feed into interleaved source/category rows, fixes a memory and freeze regression introduced by that redesign, and adds quick navigation from Front Page and My Feed rows into their full category pages.

**My Feed Redesign:**
* Redesigned My Feed as interleaved source/category rows, mirroring Front Page's `CategorySection`, with articles placed in both their source row and category row.
* Added a sliding Personalization subpage letting custom RSS feeds opt into My Feed independently of their general "enabled" switch.
* Replaced fragile fuzzy source-name matching (and a crash-prone closure-based alternative) with identity resolution done synchronously from pre-mutation data in `ArticleManager.add_item()`.
* Fixed built-in sources disappearing from My Feed under load, since the buffer eviction policy exempted My Feed entirely, letting a handful of large custom feeds crowd out every built-in article.
* Fixed circular source/category logos being stretched instead of center-cropped.

**Performance and Memory:**
* Fixed O(n^2) XML sanitization and batched card dispatch via `Idle`, fixing My Feed's slow initial load.
* Capped real card widgets per My Feed row, which was previously unbounded and could build 300-400+ live images per load, and capped HTTP concurrency more conservatively to fix the resulting memory/freeze regression.
* Tuned glibc malloc arena count and added `malloc_trim()` after My Feed's row rebuilds so freed memory is actually returned to the OS instead of sitting in fragmented arenas.

**Bug Fixes:**
* Fixed Sports' hero carousel staying empty on first load, since the sparse-category adaptive layout heuristic assumed one fetch per category, but Sports runs two concurrently and could read a mid-stream gap as "done."
* Fixed My Feed's sidebar unread badge showing inflated counts by counting every article ever registered for the category instead of what was displayed; now shows a "--" placeholder until My Feed has been opened this session.
* Fixed the "--" placeholder rendering blank instead of "--" for any freshly-created sidebar badge, affecting all popular categories, not just My Feed.
* Fixed My Feed's empty-state button pointing at the wrong preferences page; relabeled to "Personalize My Feed" and now opens Preferences directly on the Personalization tab.

**New Feature:**
* Added a "Go to <category>" button under each Front Page/My Feed row, jumping to that category's real sidebar page, and fixed a pre-existing display-name mismatch between Front Page's raw category ids and the sidebar's ids (e.g. "World"/"US" vs "World News"/"US News").

**Packaging:**
* Added a flatpak build file.

**Cleanup:**
* Trimmed overly verbose comments across reworked files.